### PR TITLE
Add `no_std` compatiblity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ panic = "abort"
 [profile.dev]
 panic = "abort"
 
+[patch.crates-io]
+serde = {default-features = false, features = ["derive", "unstable", "alloc"], path = "../serde/serde"}
+serde_derive = {default-features = false, features = ["derive", "unstable", "alloc"], path = "../serde/serde_derive"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,3 @@ panic = "abort"
 
 [profile.dev]
 panic = "abort"
-
-[patch.crates-io]
-serde = {default-features = false, features = ["derive", "unstable", "alloc"], path = "../serde/serde"}
-serde_derive = {default-features = false, features = ["derive", "unstable", "alloc"], path = "../serde/serde_derive"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/nostr",
     "crates/nostr-sdk",
     "crates/nostr-sdk-sqlite",
+    "crates/ensure_no_std"
 ]
 
 [workspace.package]
@@ -18,3 +19,8 @@ rust-version = "1.64.0"
 [profile.release]
 lto = true
 codegen-units = 1
+panic = "abort"
+
+[profile.dev]
+panic = "abort"
+

--- a/crates/ensure_no_std/Cargo.toml
+++ b/crates/ensure_no_std/Cargo.toml
@@ -9,9 +9,17 @@ edition = "2021"
 libc = { version = "0.2.119", default-features = false }
 
 nostr = { path = "../nostr", default-features = false, features = ["alloc"] }
-url_no_std = { package = "url", features = [
-    "idna",
-    "alloc",
-    "core-error",
-    "core-net",
-], path = "../../../rust-url/url", default-features = false }
+
+#secp256k1 = { version = "0.24", default-features = false, features = ["alloc", "serde", "rand"]}
+
+#rand = { version = "0.8", features = [
+#    "alloc",
+#    "getrandom",
+#], default-features = false }
+
+#url_no_std = { package = "url", features = [
+#    "idna",
+#    "alloc",
+#    "core-error",
+#    "core-net",
+#], path = "../../../rust-url/url", default-features = false }

--- a/crates/ensure_no_std/Cargo.toml
+++ b/crates/ensure_no_std/Cargo.toml
@@ -9,17 +9,3 @@ edition = "2021"
 libc = { version = "0.2.119", default-features = false }
 
 nostr = { path = "../nostr", default-features = false, features = ["alloc"] }
-
-#secp256k1 = { version = "0.24", default-features = false, features = ["alloc", "serde", "rand"]}
-
-#rand = { version = "0.8", features = [
-#    "alloc",
-#    "getrandom",
-#], default-features = false }
-
-#url_no_std = { package = "url", features = [
-#    "idna",
-#    "alloc",
-#    "core-error",
-#    "core-net",
-#], path = "../../../rust-url/url", default-features = false }

--- a/crates/ensure_no_std/Cargo.toml
+++ b/crates/ensure_no_std/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ensure_no_std"
+version = "0.7.0"
+authors = ["Supercomputing Systems AG <info@scs.ch>"]
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+libc = { version = "0.2.119", default-features = false }
+
+nostr = { path = "../nostr", default-features = false, features = ["alloc"] }
+url_no_std = { package = "url", features = [
+    "idna",
+    "alloc",
+    "core-error",
+    "core-net",
+], path = "../../../rust-url/url", default-features = false }

--- a/crates/ensure_no_std/Cargo.toml
+++ b/crates/ensure_no_std/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "ensure_no_std"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+
+[features]
+default = ["alloc"]
+alloc = []
+std = []
+
+[dependencies]
+thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false} #PASSED
+bitcoin_hashes = { version = "0.11", default-features = false, path = "../../../bitcoin_hashes", features = ["serde", "core-error"]} #PASSED WO alloc
+#serde = { version = "1.0", features = [
+ #   "derive", 
+#], default-features = false } #  #PASSED WO alloc
+
+serde = {default-features = false, features = ["derive", "unstable", "alloc"], path = "../../../serde/serde"}
+
+
+
+
+# serde_json = { version = "1.0", default-features = false} # NEED ALLOC OR STD
+#url_no_std = { package = "url", features = [
+    #"serde",
+#], branch = "no_std", git = "https://github.com/servo/rust-url", default-features = false } # CULPRIT
+url_no_std = { package = "url", features = [
+"alloc",
+"core-net",
+"core-error"
+], path = "../../../rust-url/url", default-features = false }
+
+libc = { version = "0.2.119", default-features = false }
+
+
+#WORKS
+form_urlencoded = { version = "1.1.0", path = "../../../rust-url/form_urlencoded", default-features = false, features = ["alloc"] }
+#WORKS
+idna = {path = "../../../rust-url/idna", default-features = false, features = ["alloc"] }
+
+#WORKS
+percent-encoding = {path = "../../../rust-url/percent_encoding", default-features = false, features = ["alloc"] }
+
+
+#nostr = {path = "../nostr", default-features = false, features = ["alloc"]}
+
+
+

--- a/crates/ensure_no_std/src/main.rs
+++ b/crates/ensure_no_std/src/main.rs
@@ -63,6 +63,7 @@ static ALLOCATOR: SimpleAllocator = SimpleAllocator {
 };
 unsafe impl Sync for SimpleAllocator {}
 
+// From https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html
 unsafe impl GlobalAlloc for SimpleAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let size = layout.size();

--- a/crates/ensure_no_std/src/main.rs
+++ b/crates/ensure_no_std/src/main.rs
@@ -18,8 +18,9 @@ extern "C" {
     pub fn printf(format: *const u8, ...) -> i32;
 }
 
-// use nostr;
-use url_no_std;
+use nostr;
+// use url_no_std;
+// use rand;
 
 #[no_mangle]
 // The main function, with its input arguments ignored, and an exit status is returned

--- a/crates/ensure_no_std/src/main.rs
+++ b/crates/ensure_no_std/src/main.rs
@@ -1,0 +1,99 @@
+#![feature(start, libc, lang_items)]
+#![feature(alloc_error_handler)]
+#![no_std]
+#![no_main]
+
+// The libc crate allows importing functions from C.
+extern crate libc;
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    cell::UnsafeCell,
+    panic::PanicInfo,
+    ptr::null_mut,
+    sync::atomic::{AtomicUsize, Ordering::SeqCst},
+};
+
+// A list of C functions that are being imported
+extern "C" {
+    pub fn printf(format: *const u8, ...) -> i32;
+}
+
+// use nostr;
+use url_no_std;
+
+#[no_mangle]
+// The main function, with its input arguments ignored, and an exit status is returned
+pub extern "C" fn main(_nargs: i32, _args: *const *const u8) -> i32 {
+    // Print "Hello, World" to stdout using printf
+    unsafe {
+        printf(b"Hello, World!\n" as *const u8);
+    }
+
+    // Exit with a return status of 0.
+    0
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(_panic: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[alloc_error_handler]
+fn foo(_: core::alloc::Layout) -> ! {
+    extern "C" {
+        fn abort() -> !;
+    }
+    unsafe { abort() }
+}
+
+const ARENA_SIZE: usize = 128 * 1024;
+const MAX_SUPPORTED_ALIGN: usize = 4096;
+#[repr(C, align(4096))] // 4096 == MAX_SUPPORTED_ALIGN
+struct SimpleAllocator {
+    arena: UnsafeCell<[u8; ARENA_SIZE]>,
+    remaining: AtomicUsize, // we allocate from the top, counting down
+}
+
+#[global_allocator]
+static ALLOCATOR: SimpleAllocator = SimpleAllocator {
+    arena: UnsafeCell::new([0x55; ARENA_SIZE]),
+    remaining: AtomicUsize::new(ARENA_SIZE),
+};
+unsafe impl Sync for SimpleAllocator {}
+
+unsafe impl GlobalAlloc for SimpleAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let size = layout.size();
+        let align = layout.align();
+
+        // `Layout` contract forbids making a `Layout` with align=0, or align not power of 2.
+        // So we can safely use a mask to ensure alignment without worrying about UB.
+        let align_mask_to_round_down = !(align - 1);
+
+        if align > MAX_SUPPORTED_ALIGN {
+            return null_mut()
+        }
+
+        let mut allocated = 0;
+        if self
+            .remaining
+            .fetch_update(SeqCst, SeqCst, |mut remaining| {
+                if size > remaining {
+                    return None
+                }
+                remaining -= size;
+                remaining &= align_mask_to_round_down;
+                allocated = remaining;
+                Some(remaining)
+            })
+            .is_err()
+        {
+            return null_mut()
+        };
+        (self.arena.get() as *mut u8).add(allocated)
+    }
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}

--- a/crates/ensure_no_std/src/main.rs
+++ b/crates/ensure_no_std/src/main.rs
@@ -1,0 +1,105 @@
+#![feature(start, libc, lang_items)]
+#![feature(alloc_error_handler)]
+#![no_std]
+#![no_main]
+
+
+// The libc crate allows importing functions from C.
+extern crate libc;
+use core::{
+	alloc::{GlobalAlloc, Layout},
+	cell::UnsafeCell,
+	panic::PanicInfo,
+	ptr::null_mut,
+	sync::atomic::{AtomicUsize, Ordering::SeqCst},
+};
+
+use url_no_std::Host;
+
+use serde::Deserialize;
+use idna::Config;
+use form_urlencoded::ByteSerialize;
+use percent_encoding::AsciiSet;
+
+
+// A list of C functions that are being imported
+extern "C" {
+	pub fn printf(format: *const u8, ...) -> i32;
+}
+
+#[no_mangle]
+// The main function, with its input arguments ignored, and an exit status is returned
+pub extern "C" fn main(_nargs: i32, _args: *const *const u8) -> i32 {
+	// Print "Hello, World" to stdout using printf
+	unsafe {
+		printf(b"Hello, World!\n" as *const u8);
+	}
+
+	// Exit with a return status of 0.
+	0
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(_panic: &PanicInfo<'_>) -> ! {
+	loop {}
+}
+
+#[alloc_error_handler]
+fn foo(_: core::alloc::Layout) -> ! {
+	extern "C" {
+		fn abort() -> !;
+	}
+	unsafe { abort() }
+}
+
+const ARENA_SIZE: usize = 128 * 1024;
+const MAX_SUPPORTED_ALIGN: usize = 4096;
+#[repr(C, align(4096))] // 4096 == MAX_SUPPORTED_ALIGN
+struct SimpleAllocator {
+	arena: UnsafeCell<[u8; ARENA_SIZE]>,
+	remaining: AtomicUsize, // we allocate from the top, counting down
+}
+
+#[global_allocator]
+static ALLOCATOR: SimpleAllocator = SimpleAllocator {
+	arena: UnsafeCell::new([0x55; ARENA_SIZE]),
+	remaining: AtomicUsize::new(ARENA_SIZE),
+};
+unsafe impl Sync for SimpleAllocator {}
+
+unsafe impl GlobalAlloc for SimpleAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		let size = layout.size();
+		let align = layout.align();
+
+		// `Layout` contract forbids making a `Layout` with align=0, or align not power of 2.
+		// So we can safely use a mask to ensure alignment without worrying about UB.
+		let align_mask_to_round_down = !(align - 1);
+
+		if align > MAX_SUPPORTED_ALIGN {
+			return null_mut()
+		}
+
+		let mut allocated = 0;
+		if self
+			.remaining
+			.fetch_update(SeqCst, SeqCst, |mut remaining| {
+				if size > remaining {
+					return None
+				}
+				remaining -= size;
+				remaining &= align_mask_to_round_down;
+				allocated = remaining;
+				Some(remaining)
+			})
+			.is_err()
+		{
+			return null_mut()
+		};
+		(self.arena.get() as *mut u8).add(allocated)
+	}
+	unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}

--- a/crates/ensure_no_std/src/main.rs
+++ b/crates/ensure_no_std/src/main.rs
@@ -19,8 +19,6 @@ extern "C" {
 }
 
 use nostr;
-// use url_no_std;
-// use rand;
 
 #[no_mangle]
 // The main function, with its input arguments ignored, and an exit status is returned
@@ -75,7 +73,7 @@ unsafe impl GlobalAlloc for SimpleAllocator {
         let align_mask_to_round_down = !(align - 1);
 
         if align > MAX_SUPPORTED_ALIGN {
-            return null_mut()
+            return null_mut();
         }
 
         let mut allocated = 0;
@@ -83,7 +81,7 @@ unsafe impl GlobalAlloc for SimpleAllocator {
             .remaining
             .fetch_update(SeqCst, SeqCst, |mut remaining| {
                 if size > remaining {
-                    return None
+                    return None;
                 }
                 remaining -= size;
                 remaining &= align_mask_to_round_down;
@@ -92,7 +90,7 @@ unsafe impl GlobalAlloc for SimpleAllocator {
             })
             .is_err()
         {
-            return null_mut()
+            return null_mut();
         };
         (self.arena.get() as *mut u8).add(allocated)
     }

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -29,7 +29,6 @@ alloc = [
     "serde_json/alloc",
     "url_no_std",
     "secp256k1/alloc",
-    "secp256k1/serde",
     "secp256k1/rand",
     "rand_core/alloc",
     "rand_core/getrandom",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -15,9 +15,7 @@ keywords = ["nostr", "protocol", "sdk"]
 default = ["all-nips", "std"]
 std = [
     "dep:thiserror",
-    "bitcoin_hashes/serde",
     "bitcoin_hashes/std",
-    "serde/derive",
     "serde/std",
     "serde_json/std",
     "url",
@@ -27,8 +25,6 @@ std = [
 alloc = [
     "dep:thiserror-core",
     "bitcoin_hashes/alloc",
-    "bitcoin_hashes/serde",
-    "serde/derive",
     "serde/alloc",
     "serde_json/alloc",
     "url_no_std",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -78,9 +78,8 @@ reqwest = { version = "0.11", default-features = false, features = [
 # ] }
 #secp256k1 = { version = "0.24", default-features = false}
 secp256k1 = { default-features = false, path = "../../../rust-secp256k1"}
-serde = { version = "1.0", features = [
-    "derive",
-], default-features = false, optional = true }
+serde = {default-features = false, features = ["derive", "unstable", "alloc"], path = "../../../serde/serde"}
+
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "1.0", optional = true }
 thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
@@ -89,7 +88,8 @@ url_no_std = { package = "url", features = [
     "serde",
     "idna",
     "alloc",
-    "core-error"
+    "core-error",
+    "core-net",
 ], path = "../../../rust-url/url", optional = true, default-features = false }
 
 rand_core = { version = "0.6", features = [
@@ -102,6 +102,9 @@ rand = { version = "0.8", features = [
     "getrandom",
     "serde1",
 ], default-features = false, optional = true }
+
+
+
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]
 #getrandom = { version = "0.2", features = ["js"] }

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -81,7 +81,7 @@ thiserror-core = { version = "1.0", package = "thiserror-core", default-features
 url = { version = "2", features = ["serde"], optional = true }
 url_no_std = { package = "url", features = [
     "serde",
-], branch = "no_std", git = "https://github.com/OverOrion/rust-url", optional = true }
+], rev = "6385c81d9b8aa09744359155c180c252d7c111be", git = "https://github.com/servo/rust-url", optional = true }
 
 rand_core = { version = "0.6", features = [
     "alloc",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -32,6 +32,9 @@ alloc = [
     "serde_json/alloc",
     "url_no_std",
     "secp256k1/alloc",
+    "secp256k1/serde",
+    "secp256k1/rand",
+    "secp256k1/core-error",
     "rand_core",
     "rand",
 
@@ -67,7 +70,8 @@ reqwest = { version = "0.11", default-features = false, features = [
 # "rand-std",
 # "serde",
 # ] }
-secp256k1 = { version = "0.24", default-features = false }
+#secp256k1 = { version = "0.24", default-features = false}
+secp256k1 = { default-features = false, path = "../../../rust-secp256k1"}
 serde = { version = "1.0", features = [
     "derive",
 ], default-features = false, optional = true }

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -12,7 +12,8 @@ rust-version.workspace = true
 keywords = ["nostr", "protocol", "sdk"]
 
 [features]
-default = ["all-nips"]
+default = ["all-nips", "std"]
+std = []
 blocking = ["reqwest?/blocking"]
 vanity = ["nip19"]
 all-nips = ["nip04", "nip05", "nip06", "nip11", "nip19", "nip46"]

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -62,7 +62,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls-webpki-roots",
     "socks",
 ], optional = true }
-secp256k1 = { version = "0.24", default-features = false}
+secp256k1 = { version = "0.24", default-features = false, features = ["serde"]}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -13,8 +13,28 @@ keywords = ["nostr", "protocol", "sdk"]
 
 [features]
 default = ["all-nips", "std"]
-std = ["dep:thiserror"]
-alloc = ["dep:thiserror-core"]
+std = [
+    "dep:thiserror",
+    "bitcoin_hashes/serde",
+    "serde/derive",
+    "serde/std",
+    "serde_json/std",
+    "url",
+    "secp256k1/global-context",
+    "secp256k1/rand-std",
+    "secp256k1/serde",
+]
+alloc = [
+    "dep:thiserror-core",
+    "bitcoin_hashes/alloc",
+    "bitcoin_hashes/serde",
+    "serde/derive",
+    "serde_json/alloc",
+    "url_no_std",
+    "secp256k1/alloc",
+    "rand_core",
+
+]
 blocking = ["reqwest?/blocking"]
 vanity = ["nip19"]
 all-nips = ["nip04", "nip05", "nip06", "nip11", "nip19", "nip46"]
@@ -32,29 +52,42 @@ base64 = { version = "0.21", optional = true }
 bech32 = { version = "0.9", optional = true }
 bip39 = { version = "2.0", optional = true }
 bitcoin = { version = "0.29", optional = true }
-bitcoin_hashes = { version = "0.11", features = ["serde"] }
+bitcoin_hashes = { version = "0.11", optional = true }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
-log = "0.4"
+log = "0.4" # no_std compatible by-default
 nostr-ots = { version = "0.2", optional = true }
 reqwest = { version = "0.11", default-features = false, features = [
     "json",
     "rustls-tls-webpki-roots",
     "socks",
 ], optional = true }
-secp256k1 = { version = "0.24", features = [
-    "global-context",
-    "rand-std",
-    "serde",
-] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+# secp256k1 = { version = "0.24", features = [
+# "global-context",
+# "rand-std",
+# "serde",
+# ] }
+secp256k1 = { version = "0.24", default-features = false }
+serde = { version = "1.0", features = [
+    "derive",
+], default-features = false, optional = true }
+serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "1.0", optional = true }
 thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
-url = { version = "2", features = ["serde"] }
+url = { version = "2", features = ["serde"], optional = true }
+url_no_std = { package = "url", features = [
+    "serde",
+], branch = "no_std", git = "https://github.com/OverOrion/rust-url", optional = true }
+
+rand_core = { version = "0.6", features = [
+    "alloc",
+    "getrandom",
+], optional = true }
+
+rand = { version = "0.8", features = ["alloc", "getrandom"], optional = true }
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
+#getrandom = { version = "0.2", features = ["js"] }
+#instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 
 [dev-dependencies]
 csv = "1.1.5"

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["nostr", "protocol", "sdk"]
 [features]
 default = ["all-nips", "std"]
 std = ["dep:thiserror"]
-alloc = ["dep:thiserror-core", "dep:chrono"]
+alloc = ["dep:thiserror-core"]
 blocking = ["reqwest?/blocking"]
 vanity = ["nip19"]
 all-nips = ["nip04", "nip05", "nip06", "nip11", "nip19", "nip46"]
@@ -51,9 +51,6 @@ serde_json = { version = "1.0" }
 thiserror = { version = "1.0", optional = true }
 thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
 url = { version = "2", features = ["serde"] }
-chrono = { version = "0.4", optional = true, default-features = false, features = [
-    "alloc",
-] }
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -33,6 +33,7 @@ alloc = [
     "url_no_std",
     "secp256k1/alloc",
     "rand_core",
+    "rand",
 
 ]
 blocking = ["reqwest?/blocking"]
@@ -83,7 +84,11 @@ rand_core = { version = "0.6", features = [
     "getrandom",
 ], optional = true }
 
-rand = { version = "0.8", features = ["alloc", "getrandom"], optional = true }
+rand = { version = "0.8", features = [
+    "alloc",
+    "getrandom",
+    "serde1",
+], optional = true }
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]
 #getrandom = { version = "0.2", features = ["js"] }

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -69,11 +69,8 @@ thiserror = { version = "1.0", optional = true }
 thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
 url = { version = "2", features = ["serde"], optional = true }
 url_no_std = { package = "url", features = [
-    "idna",
     "alloc",
-    "core-error",
-    "core-net",
-], path = "../../../rust-url/url", optional = true, default-features = false }
+], git = "https://github.com/domenukk/rust-url", branch = "no_std", optional = true, default-features = false }
 
 rand_core = { version = "0.6", features = [
     "alloc",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -73,7 +73,7 @@ thiserror-core = { version = "1.0", package = "thiserror-core", default-features
 url = { version = "2", features = ["serde"], optional = true }
 url_no_std = { package = "url", features = [
     "alloc",
-], git = "https://github.com/domenukk/rust-url", branch = "no_std", optional = true, default-features = false }
+], git = "https://github.com/OverOrion/rust-url", branch = "no_std_net", optional = true, default-features = false }
 
 rand_core = { version = "0.6", features = [
     "alloc",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -29,7 +29,6 @@ alloc = [
     "dep:thiserror-core",
     "bitcoin_hashes/alloc",
     "bitcoin_hashes/serde",
-    "bitcoin_hashes/core-error",
     "serde/derive",
     "serde/alloc",
     "serde_json/alloc",
@@ -37,7 +36,6 @@ alloc = [
     "secp256k1/alloc",
     "secp256k1/serde",
     "secp256k1/rand",
-    "secp256k1/core-error",
     "rand_core/alloc",
     "rand_core/getrandom",
     "rand/alloc",
@@ -61,8 +59,7 @@ base64 = { version = "0.21", optional = true }
 bech32 = { version = "0.9", optional = true }
 bip39 = { version = "2.0", optional = true }
 bitcoin = { version = "0.29", optional = true }
-#bitcoin_hashes = { version = "0.11", optional = true, default-features = false }
-bitcoin_hashes = { version = "0.11", optional = true, default-features = false, path = "../../../bitcoin_hashes" }
+bitcoin_hashes = { version = "0.11", optional = true, default-features = false }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = "0.4" # no_std compatible by-default
 nostr-ots = { version = "0.2", optional = true }
@@ -76,9 +73,8 @@ reqwest = { version = "0.11", default-features = false, features = [
 # "rand-std",
 # "serde",
 # ] }
-#secp256k1 = { version = "0.24", default-features = false}
-secp256k1 = { default-features = false, path = "../../../rust-secp256k1"}
-serde = {default-features = false, features = ["derive", "unstable", "alloc"], path = "../../../serde/serde"}
+secp256k1 = { version = "0.24", default-features = false}
+serde = { version = "1.0", default-features = false, features = ["derive", "unstable", "alloc"] }
 
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "1.0", optional = true }

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -86,9 +86,9 @@ rand = { version = "0.8", features = [
 ], default-features = false, optional = true }
 
 
-#[target.'cfg(target_arch = "wasm32")'.dependencies]
-#getrandom = { version = "0.2", features = ["js"] }
-#instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 
 [dev-dependencies]
 csv = "1.1.5"

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -13,7 +13,8 @@ keywords = ["nostr", "protocol", "sdk"]
 
 [features]
 default = ["all-nips", "std"]
-std = []
+std = ["dep:thiserror"]
+alloc = ["dep:thiserror-core"]
 blocking = ["reqwest?/blocking"]
 vanity = ["nip19"]
 all-nips = ["nip04", "nip05", "nip06", "nip11", "nip19", "nip46"]
@@ -39,7 +40,8 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 secp256k1 = { version = "0.24", features = ["global-context", "rand-std", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-thiserror = "1.0"
+thiserror = {version = "1.0", optional = true}
+thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
 url = { version = "2", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["nostr", "protocol", "sdk"]
 [features]
 default = ["all-nips", "std"]
 std = ["dep:thiserror"]
-alloc = ["dep:thiserror-core"]
+alloc = ["dep:thiserror-core", "dep:chrono"]
 blocking = ["reqwest?/blocking"]
 vanity = ["nip19"]
 all-nips = ["nip04", "nip05", "nip06", "nip11", "nip19", "nip46"]
@@ -36,17 +36,28 @@ bitcoin_hashes = { version = "0.11", features = ["serde"] }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = "0.4"
 nostr-ots = { version = "0.2", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots", "socks"], optional = true }
-secp256k1 = { version = "0.24", features = ["global-context", "rand-std", "serde"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "json",
+    "rustls-tls-webpki-roots",
+    "socks",
+], optional = true }
+secp256k1 = { version = "0.24", features = [
+    "global-context",
+    "rand-std",
+    "serde",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-thiserror = {version = "1.0", optional = true}
+thiserror = { version = "1.0", optional = true }
 thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
 url = { version = "2", features = ["serde"] }
+chrono = { version = "0.4", optional = true, default-features = false, features = [
+    "alloc",
+] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+#[target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-instant = { version = "0.1", features = [ "wasm-bindgen", "inaccurate" ] }
+instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 
 [dev-dependencies]
 csv = "1.1.5"

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -43,16 +43,19 @@ nip04 = ["dep:aes", "dep:base64", "dep:cbc"]
 nip05 = ["dep:reqwest"]
 nip06 = ["dep:bip39", "dep:bitcoin"]
 nip11 = ["dep:reqwest"]
-nip19 = ["dep:bech32"]
+nip19 = ["bech32/alloc"]
+nip19-std = ["bech32/std"]
 nip46 = ["nip04"]
 
 [dependencies]
 aes = { version = "0.8", optional = true }
 base64 = { version = "0.21", optional = true }
-bech32 = { version = "0.9", optional = true }
+bech32 = { git = "https://github.com/rust-bitcoin/rust-bech32", rev = "360af7e0647fa94bce892fa69f31c0ef02452b63", optional = true, default-features = false }
 bip39 = { version = "2.0", optional = true }
 bitcoin = { version = "0.29", optional = true }
-bitcoin_hashes = { version = "0.11", default-features = false, features = ["serde"] }
+bitcoin_hashes = { version = "0.11", default-features = false, features = [
+    "serde",
+] }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = "0.4" # no_std compatible by-default
 nostr-ots = { version = "0.2", optional = true }
@@ -61,7 +64,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls-webpki-roots",
     "socks",
 ], optional = true }
-secp256k1 = { version = "0.24", default-features = false, features = ["serde"]}
+secp256k1 = { version = "0.24", default-features = false, features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 
@@ -75,14 +78,12 @@ url_no_std = { package = "url", features = [
 rand_core = { version = "0.6", features = [
     "alloc",
     "getrandom",
-], optional = true, default-features = false}
+], optional = true, default-features = false }
 
 rand = { version = "0.8", features = [
     "alloc",
     "getrandom",
 ], default-features = false, optional = true }
-
-
 
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -23,7 +23,6 @@ std = [
     "url",
     "secp256k1/global-context",
     "secp256k1/rand-std",
-    "secp256k1/serde",
 ]
 alloc = [
     "dep:thiserror-core",
@@ -40,7 +39,6 @@ alloc = [
     "rand_core/getrandom",
     "rand/alloc",
     "rand/getrandom",
-    "rand/serde1",
 ]
 blocking = ["reqwest?/blocking"]
 vanity = ["nip19"]
@@ -59,7 +57,7 @@ base64 = { version = "0.21", optional = true }
 bech32 = { version = "0.9", optional = true }
 bip39 = { version = "2.0", optional = true }
 bitcoin = { version = "0.29", optional = true }
-bitcoin_hashes = { version = "0.11", optional = true, default-features = false }
+bitcoin_hashes = { version = "0.11", default-features = false, features = ["serde"] }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = "0.4" # no_std compatible by-default
 nostr-ots = { version = "0.2", optional = true }
@@ -68,15 +66,10 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls-webpki-roots",
     "socks",
 ], optional = true }
-# secp256k1 = { version = "0.24", features = [
-# "global-context",
-# "rand-std",
-# "serde",
-# ] }
 secp256k1 = { version = "0.24", default-features = false}
-serde = { version = "1.0", default-features = false, features = ["derive", "unstable", "alloc"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0", default-features = false }
 
-serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "1.0", optional = true }
 thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
 url = { version = "2", features = ["serde"], optional = true }
@@ -95,7 +88,6 @@ rand_core = { version = "0.6", features = [
 rand = { version = "0.8", features = [
     "alloc",
     "getrandom",
-    "serde1",
 ], default-features = false, optional = true }
 
 

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -81,7 +81,6 @@ thiserror = { version = "1.0", optional = true }
 thiserror-core = { version = "1.0", package = "thiserror-core", default-features = false, optional = true }
 url = { version = "2", features = ["serde"], optional = true }
 url_no_std = { package = "url", features = [
-    "serde",
     "idna",
     "alloc",
     "core-error",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -16,6 +16,7 @@ default = ["all-nips", "std"]
 std = [
     "dep:thiserror",
     "bitcoin_hashes/serde",
+    "bitcoin_hashes/std",
     "serde/derive",
     "serde/std",
     "serde_json/std",
@@ -28,16 +29,20 @@ alloc = [
     "dep:thiserror-core",
     "bitcoin_hashes/alloc",
     "bitcoin_hashes/serde",
+    "bitcoin_hashes/core-error",
     "serde/derive",
+    "serde/alloc",
     "serde_json/alloc",
     "url_no_std",
     "secp256k1/alloc",
     "secp256k1/serde",
     "secp256k1/rand",
     "secp256k1/core-error",
-    "rand_core",
-    "rand",
-
+    "rand_core/alloc",
+    "rand_core/getrandom",
+    "rand/alloc",
+    "rand/getrandom",
+    "rand/serde1",
 ]
 blocking = ["reqwest?/blocking"]
 vanity = ["nip19"]
@@ -56,7 +61,8 @@ base64 = { version = "0.21", optional = true }
 bech32 = { version = "0.9", optional = true }
 bip39 = { version = "2.0", optional = true }
 bitcoin = { version = "0.29", optional = true }
-bitcoin_hashes = { version = "0.11", optional = true }
+#bitcoin_hashes = { version = "0.11", optional = true, default-features = false }
+bitcoin_hashes = { version = "0.11", optional = true, default-features = false, path = "../../../bitcoin_hashes" }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = "0.4" # no_std compatible by-default
 nostr-ots = { version = "0.2", optional = true }
@@ -81,18 +87,21 @@ thiserror-core = { version = "1.0", package = "thiserror-core", default-features
 url = { version = "2", features = ["serde"], optional = true }
 url_no_std = { package = "url", features = [
     "serde",
-], rev = "6385c81d9b8aa09744359155c180c252d7c111be", git = "https://github.com/servo/rust-url", optional = true }
+    "idna",
+    "alloc",
+    "core-error"
+], path = "../../../rust-url/url", optional = true, default-features = false }
 
 rand_core = { version = "0.6", features = [
     "alloc",
     "getrandom",
-], optional = true }
+], optional = true, default-features = false}
 
 rand = { version = "0.8", features = [
     "alloc",
     "getrandom",
     "serde1",
-], optional = true }
+], default-features = false, optional = true }
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]
 #getrandom = { version = "0.2", features = ["js"] }

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -60,9 +60,20 @@ impl EventBuilder {
     }
 
     /// Build [`Event`]
+    #[cfg(feature = "std")]
     pub fn to_event(self, keys: &Keys) -> Result<Event, Error> {
-        let pubkey: XOnlyPublicKey = keys.public_key();
         let created_at: Timestamp = Timestamp::now();
+
+        Self::to_event_internal(self, keys, created_at)
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn to_event_with_timestamp(self, keys: &Keys, created_at: Timestamp) -> Result<Event, Error> {
+        Self::to_event_internal(self, keys, created_at)
+    }
+
+    fn to_event_internal(self, keys: &Keys, created_at: Timestamp) -> Result<Event, Error> {
+        let pubkey: XOnlyPublicKey = keys.public_key();
 
         let id = EventId::new(&pubkey, created_at, &self.kind, &self.tags, &self.content);
         let message = Message::from_slice(id.as_bytes())?;
@@ -81,7 +92,16 @@ impl EventBuilder {
     }
 
     /// Build POW [`Event`]
+    #[cfg(feature = "std")]
     pub fn to_pow_event(self, keys: &Keys, difficulty: u8) -> Result<Event, Error> {
+
+    }
+    #[cfg(feature = "std")]
+    pub fn to_pow_event_with_time_supplier(self, keys: &Keys, difficulty: u8, time_supplier: &impl TimeSupplier) -> Result<Event, Error> {
+
+    }
+
+    fn to_pow_event_internal(self, keys: &Keys, difficulty: u8, time_supplier: &impl TimeSupplier) -> Result<Event, Error> {
         #[cfg(target_arch = "wasm32")]
         use instant::Instant;
         #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
@@ -133,8 +153,19 @@ impl EventBuilder {
     }
 
     /// Build [`UnsignedEvent`]
+    #[cfg(feature = "std")]
     pub fn to_unsigned_event(self, pubkey: XOnlyPublicKey) -> UnsignedEvent {
         let created_at: Timestamp = Timestamp::now();
+
+        Self::to_unsigned_event_internal(self, pubkey, created_at)
+        
+    }
+    #[cfg(not(feature = "std"))]
+    pub fn to_unsigned_event_with_timestamp(self, pubkey: XOnlyPublicKey, created_at: Timestamp) -> UnsignedEvent {
+        Self::to_unsigned_event_internal(self, pubkey, created_at)
+    }
+
+    fn to_unsigned_event_internal(self, pubkey: XOnlyPublicKey, created_at: Timestamp) -> UnsignedEvent {
         let id = EventId::new(&pubkey, created_at, &self.kind, &self.tags, &self.content);
         UnsignedEvent {
             id,
@@ -144,6 +175,7 @@ impl EventBuilder {
             tags: self.tags,
             content: self.content,
         }
+
     }
 }
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -101,7 +101,12 @@ impl EventBuilder {
 
     /// Build POW [`Event`]
     #[cfg(feature = "std")]
-    pub fn to_pow_event(self, keys: &Keys, difficulty: u8) -> Result<Event, Error> {}
+    pub fn to_pow_event(self, keys: &Keys, difficulty: u8) -> Result<Event, Error> {
+        #[cfg(target_arch = "wasm32")]
+        use instant::Instant;
+        #[cfg(target_arch = "wasm32")]
+        self.to_pow_event_with_time_supplier(self, keys, difficulty, Instant);
+    }
     #[cfg(feature = "std")]
     pub fn to_pow_event_with_time_supplier(
         self,
@@ -111,12 +116,15 @@ impl EventBuilder {
     ) -> Result<Event, Error> {
     }
 
-    fn to_pow_event_internal(
+    fn to_pow_event_internal<T>(
         self,
         keys: &Keys,
         difficulty: u8,
-        time_supplier: &impl TimeSupplier,
-    ) -> Result<Event, Error> {
+        time_supplier: &T,
+    ) -> Result<Event, Error>
+    where
+        T: TimeSupplier,
+    {
         #[cfg(target_arch = "wasm32")]
         use instant::Instant;
         #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
@@ -138,15 +146,21 @@ impl EventBuilder {
 
             tags.push(Tag::POW { nonce, difficulty });
 
-            let created_at: Timestamp = Timestamp::now();
+            //let created_at: Timestamp = Timestamp::now();
+            let new_now = time_supplier.now();
+            let starting_point = time_supplier.starting_point();
+            let created_at = time_supplier.elapsed_duration(new_now.clone(), starting_point);
+            let created_at = time_supplier.to_timestamp(created_at);
             let id = EventId::new(&pubkey, created_at, &self.kind, &tags, &self.content);
 
             if nip13::get_leading_zero_bits(id.inner()) >= difficulty {
                 log::debug!(
                     "{} iterations in {} ms. Avg rate {} hashes/second",
                     nonce,
-                    now.elapsed().as_millis(),
-                    nonce * 1000 / cmp::max(1, now.elapsed().as_millis())
+                    //now.elapsed().as_millis(),
+                    time_supplier.elapsed_since(now.clone(), new_now.clone()).as_millis(),
+                    nonce * 1000
+                        / cmp::max(1, time_supplier.elapsed_since(now, new_now).as_millis())
                 );
 
                 let message = Message::from_slice(id.as_bytes())?;

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -132,8 +132,13 @@ impl EventBuilder {
     pub fn to_pow_event(self, keys: &Keys, difficulty: u8) -> Result<Event, Error> {
         #[cfg(target_arch = "wasm32")]
         use instant::Instant;
-        #[cfg(target_arch = "wasm32")]
-        self.to_pow_event_with_time_supplier_with_secp(self, keys, difficulty, Instant, SECP256K1);
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+        use std::time::Instant;
+
+        let now = Instant::now();
+
+        use secp256k1::SECP256K1;
+        self.to_pow_event_with_time_supplier_with_secp::<Instant, _>(keys, difficulty, &now, SECP256K1)
     }
 
     /// Build POW [`Event`] using the given time supplier
@@ -163,9 +168,9 @@ impl EventBuilder {
         #[cfg(target_arch = "wasm32")]
         use instant::Instant;
         #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
-        use std::{cmp, time::Instant};
+        use std::cmp;
 
-        #[cfg(feature = "alloc")]
+        #[cfg(all(feature = "alloc", not(feature = "std")))]
         use core::cmp;
 
         let mut nonce: u128 = 0;
@@ -198,7 +203,13 @@ impl EventBuilder {
                 );
 
                 let message = Message::from_slice(id.as_bytes())?;
+
+                #[cfg(all(feature = "alloc", not(feature = "std")))]
                 let sig = keys.sign_schnorr_with_secp(&message, &secp)?;
+
+                #[cfg(all(feature = "std", not(feature = "alloc")))]
+                let sig = keys.sign_schnorr(&message)?;
+
 
                 return self.to_event_internal(keys, created_at, id, sig);
             }

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -107,13 +107,17 @@ impl EventBuilder {
         #[cfg(target_arch = "wasm32")]
         self.to_pow_event_with_time_supplier(self, keys, difficulty, Instant);
     }
-    #[cfg(feature = "std")]
-    pub fn to_pow_event_with_time_supplier(
+
+    pub fn to_pow_event_with_time_supplier<T>(
         self,
         keys: &Keys,
         difficulty: u8,
         time_supplier: &impl TimeSupplier,
-    ) -> Result<Event, Error> {
+    ) -> Result<Event, Error>
+    where
+        T: TimeSupplier,
+    {
+        self.to_pow_event_internal(keys, difficulty, time_supplier)
     }
 
     fn to_pow_event_internal<T>(
@@ -138,7 +142,6 @@ impl EventBuilder {
 
         let pubkey = keys.public_key();
 
-        //let now = Instant::now();
         let now = time_supplier.now();
 
         loop {
@@ -146,7 +149,6 @@ impl EventBuilder {
 
             tags.push(Tag::POW { nonce, difficulty });
 
-            //let created_at: Timestamp = Timestamp::now();
             let new_now = time_supplier.now();
             let starting_point = time_supplier.starting_point();
             let created_at = time_supplier.elapsed_duration(new_now.clone(), starting_point);
@@ -157,8 +159,9 @@ impl EventBuilder {
                 log::debug!(
                     "{} iterations in {} ms. Avg rate {} hashes/second",
                     nonce,
-                    //now.elapsed().as_millis(),
-                    time_supplier.elapsed_since(now.clone(), new_now.clone()).as_millis(),
+                    time_supplier
+                        .elapsed_since(now.clone(), new_now.clone())
+                        .as_millis(),
                     nonce * 1000
                         / cmp::max(1, time_supplier.elapsed_since(now, new_now).as_millis())
                 );

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -71,6 +71,7 @@ impl EventBuilder {
         Self::to_event_internal(self, keys, created_at)
     }
 
+    /// Build [`Event`] with a `timestamp`
     #[cfg(not(feature = "std"))]
     pub fn to_event_with_timestamp(
         self,
@@ -108,6 +109,7 @@ impl EventBuilder {
         self.to_pow_event_with_time_supplier(self, keys, difficulty, Instant);
     }
 
+    /// Build POW [`Event`] using the given time supplier
     pub fn to_pow_event_with_time_supplier<T>(
         self,
         keys: &Keys,
@@ -193,6 +195,9 @@ impl EventBuilder {
         Self::to_unsigned_event_internal(self, pubkey, created_at)
     }
     #[cfg(not(feature = "std"))]
+    /// Build [`UnsignedEvent`] with the given `Timestamp`
+    /// Mostly useful for cases where the time source comes from the outside, not from builtin
+    /// functions
     pub fn to_unsigned_event_with_timestamp(
         self,
         pubkey: XOnlyPublicKey,

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -158,7 +158,7 @@ impl EventBuilder {
         use core::cmp;
 
         let mut nonce: u128 = 0;
-        let mut tags: Vec<Tag> = self.tags;
+        let mut tags: Vec<Tag> = self.tags.clone();
 
         let pubkey = keys.public_key();
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -8,7 +8,10 @@ use alloc::{
     vec::Vec,
 };
 
+use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};
+#[cfg(not(feature = "std"))]
+use secp256k1::{Secp256k1, Signing};
 use serde_json::{json, Value};
 use url::Url;
 
@@ -66,26 +69,39 @@ impl EventBuilder {
     /// Build [`Event`]
     #[cfg(feature = "std")]
     pub fn to_event(self, keys: &Keys) -> Result<Event, Error> {
+        let pubkey: XOnlyPublicKey = keys.public_key();
         let created_at: Timestamp = Timestamp::now();
+        let id = EventId::new(&pubkey, created_at, &self.kind, &self.tags, &self.content);
+        let message = Message::from_slice(id.as_bytes())?;
+        let signature = keys.sign_schnorr(&message)?;
 
-        Self::to_event_internal(self, keys, created_at)
+        Self::to_event_internal(self, keys, created_at, id, signature)
     }
 
     /// Build [`Event`] with a `timestamp`
     #[cfg(not(feature = "std"))]
-    pub fn to_event_with_timestamp(
+    pub fn to_event_with_timestamp_with_secp<C: Signing>(
         self,
         keys: &Keys,
         created_at: Timestamp,
+        secp: &Secp256k1<C>,
     ) -> Result<Event, Error> {
-        Self::to_event_internal(self, keys, created_at)
-    }
-
-    fn to_event_internal(self, keys: &Keys, created_at: Timestamp) -> Result<Event, Error> {
         let pubkey: XOnlyPublicKey = keys.public_key();
-
         let id = EventId::new(&pubkey, created_at, &self.kind, &self.tags, &self.content);
         let message = Message::from_slice(id.as_bytes())?;
+        let signature = keys.sign_schnorr_with_secp(&message, secp)?;
+
+        Self::to_event_internal(self, keys, created_at, id, signature)
+    }
+
+    fn to_event_internal(
+        self,
+        keys: &Keys,
+        created_at: Timestamp,
+        id: EventId,
+        sig: Signature,
+    ) -> Result<Event, Error> {
+        let pubkey: XOnlyPublicKey = keys.public_key();
 
         Ok(Event {
             id,
@@ -94,7 +110,7 @@ impl EventBuilder {
             kind: self.kind,
             tags: self.tags,
             content: self.content,
-            sig: keys.sign_schnorr(&message)?,
+            sig,
             #[cfg(feature = "nip03")]
             ots: None,
         })
@@ -106,27 +122,29 @@ impl EventBuilder {
         #[cfg(target_arch = "wasm32")]
         use instant::Instant;
         #[cfg(target_arch = "wasm32")]
-        self.to_pow_event_with_time_supplier(self, keys, difficulty, Instant);
+        self.to_pow_event_with_time_supplier_with_secp(self, keys, difficulty, Instant, SECP256K1);
     }
 
     /// Build POW [`Event`] using the given time supplier
-    pub fn to_pow_event_with_time_supplier<T>(
+    pub fn to_pow_event_with_time_supplier_with_secp<T, C: Signing>(
         self,
         keys: &Keys,
         difficulty: u8,
         time_supplier: &impl TimeSupplier,
+        secp: &Secp256k1<C>,
     ) -> Result<Event, Error>
     where
         T: TimeSupplier,
     {
-        self.to_pow_event_internal(keys, difficulty, time_supplier)
+        self.to_pow_event_internal(keys, difficulty, time_supplier, secp)
     }
 
-    fn to_pow_event_internal<T>(
+    fn to_pow_event_internal<T, C: Signing>(
         self,
         keys: &Keys,
         difficulty: u8,
         time_supplier: &T,
+        secp: &Secp256k1<C>,
     ) -> Result<Event, Error>
     where
         T: TimeSupplier,
@@ -169,18 +187,9 @@ impl EventBuilder {
                 );
 
                 let message = Message::from_slice(id.as_bytes())?;
+                let sig = keys.sign_schnorr_with_secp(&message, &secp)?;
 
-                return Ok(Event {
-                    id,
-                    pubkey,
-                    created_at,
-                    kind: self.kind,
-                    tags,
-                    content: self.content,
-                    sig: keys.sign_schnorr(&message)?,
-                    #[cfg(feature = "nip03")]
-                    ots: None,
-                });
+                return self.to_event_internal(keys, created_at, id, sig);
             }
 
             tags.pop();

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -33,9 +33,9 @@ pub enum Error {
     /// Key error
     #[error(transparent)]
     Key(#[from] key::Error),
-    #[error(transparent)]
     /// Secp256k1 error
-    Secp256k1(#[from] secp256k1::Error),
+    #[error("Secp256k1 Error: {0}")]
+    Secp256k1(secp256k1::Error),
     /// JSON error
     #[error(transparent)]
     Json(#[from] serde_json::Error),
@@ -43,6 +43,12 @@ pub enum Error {
     #[cfg(feature = "nip04")]
     #[error(transparent)]
     NIP04(#[from] nip04::Error),
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(error: secp256k1::Error) -> Self {
+        Self::Secp256k1(error)
+    }
 }
 
 /// [`Event`] builder

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -10,7 +10,6 @@ use alloc::{
 
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};
-#[cfg(not(feature = "std"))]
 use secp256k1::{Secp256k1, Signing};
 use serde_json::{json, Value};
 use url::Url;

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -36,8 +36,8 @@ pub enum Error {
     #[error("Secp256k1 Error: {0}")]
     Secp256k1(secp256k1::Error),
     /// JSON error
-    #[error(transparent)]
-    Json(#[from] serde_json::Error),
+    #[error("Serde json Error: {0}")]
+    Json(serde_json::Error),
     /// NIP04 error
     #[cfg(feature = "nip04")]
     #[error(transparent)]
@@ -47,6 +47,12 @@ pub enum Error {
 impl From<secp256k1::Error> for Error {
     fn from(error: secp256k1::Error) -> Self {
         Self::Secp256k1(error)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
     }
 }
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -3,7 +3,10 @@
 
 //! Event builder
 #[cfg(feature = "alloc")]
-use alloc::{string::{String, ToString}, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use secp256k1::{Message, XOnlyPublicKey};
 use serde_json::{json, Value};
@@ -18,6 +21,7 @@ use crate::nips::nip04;
 use crate::nips::nip13;
 #[cfg(feature = "nip46")]
 use crate::nips::nip46::Message as NostrConnectMessage;
+use crate::types::time::TimeSupplier;
 use crate::types::{ChannelId, Contact, Metadata, Timestamp};
 
 /// [`EventBuilder`] error
@@ -68,7 +72,11 @@ impl EventBuilder {
     }
 
     #[cfg(not(feature = "std"))]
-    pub fn to_event_with_timestamp(self, keys: &Keys, created_at: Timestamp) -> Result<Event, Error> {
+    pub fn to_event_with_timestamp(
+        self,
+        keys: &Keys,
+        created_at: Timestamp,
+    ) -> Result<Event, Error> {
         Self::to_event_internal(self, keys, created_at)
     }
 
@@ -93,15 +101,22 @@ impl EventBuilder {
 
     /// Build POW [`Event`]
     #[cfg(feature = "std")]
-    pub fn to_pow_event(self, keys: &Keys, difficulty: u8) -> Result<Event, Error> {
-
-    }
+    pub fn to_pow_event(self, keys: &Keys, difficulty: u8) -> Result<Event, Error> {}
     #[cfg(feature = "std")]
-    pub fn to_pow_event_with_time_supplier(self, keys: &Keys, difficulty: u8, time_supplier: &impl TimeSupplier) -> Result<Event, Error> {
-
+    pub fn to_pow_event_with_time_supplier(
+        self,
+        keys: &Keys,
+        difficulty: u8,
+        time_supplier: &impl TimeSupplier,
+    ) -> Result<Event, Error> {
     }
 
-    fn to_pow_event_internal(self, keys: &Keys, difficulty: u8, time_supplier: &impl TimeSupplier) -> Result<Event, Error> {
+    fn to_pow_event_internal(
+        self,
+        keys: &Keys,
+        difficulty: u8,
+        time_supplier: &impl TimeSupplier,
+    ) -> Result<Event, Error> {
         #[cfg(target_arch = "wasm32")]
         use instant::Instant;
         #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
@@ -115,7 +130,8 @@ impl EventBuilder {
 
         let pubkey = keys.public_key();
 
-        let now = Instant::now();
+        //let now = Instant::now();
+        let now = time_supplier.now();
 
         loop {
             nonce += 1;
@@ -158,14 +174,21 @@ impl EventBuilder {
         let created_at: Timestamp = Timestamp::now();
 
         Self::to_unsigned_event_internal(self, pubkey, created_at)
-        
     }
     #[cfg(not(feature = "std"))]
-    pub fn to_unsigned_event_with_timestamp(self, pubkey: XOnlyPublicKey, created_at: Timestamp) -> UnsignedEvent {
+    pub fn to_unsigned_event_with_timestamp(
+        self,
+        pubkey: XOnlyPublicKey,
+        created_at: Timestamp,
+    ) -> UnsignedEvent {
         Self::to_unsigned_event_internal(self, pubkey, created_at)
     }
 
-    fn to_unsigned_event_internal(self, pubkey: XOnlyPublicKey, created_at: Timestamp) -> UnsignedEvent {
+    fn to_unsigned_event_internal(
+        self,
+        pubkey: XOnlyPublicKey,
+        created_at: Timestamp,
+    ) -> UnsignedEvent {
         let id = EventId::new(&pubkey, created_at, &self.kind, &self.tags, &self.content);
         UnsignedEvent {
             id,
@@ -175,7 +198,6 @@ impl EventBuilder {
             tags: self.tags,
             content: self.content,
         }
-
     }
 }
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -160,7 +160,7 @@ impl EventBuilder {
         keys: &Keys,
         difficulty: u8,
         time_supplier: &T,
-        secp: &Secp256k1<C>,
+        _secp: &Secp256k1<C>,
     ) -> Result<Event, Error>
     where
         T: TimeSupplier,
@@ -186,8 +186,7 @@ impl EventBuilder {
             tags.push(Tag::POW { nonce, difficulty });
 
             let new_now = time_supplier.now();
-            let starting_point = time_supplier.starting_point();
-            let created_at = time_supplier.elapsed_duration(new_now.clone(), starting_point);
+            let created_at = time_supplier.duration_since_starting_point(now.clone());
             let created_at = time_supplier.to_timestamp(created_at);
             let id = EventId::new(&pubkey, created_at, &self.kind, &tags, &self.content);
 
@@ -205,7 +204,7 @@ impl EventBuilder {
                 let message = Message::from_slice(id.as_bytes())?;
 
                 #[cfg(all(feature = "alloc", not(feature = "std")))]
-                let sig = keys.sign_schnorr_with_secp(&message, &secp)?;
+                let sig = keys.sign_schnorr_with_secp(&message, &_secp)?;
 
                 #[cfg(all(feature = "std", not(feature = "alloc")))]
                 let sig = keys.sign_schnorr(&message)?;

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -3,7 +3,7 @@
 
 //! Event builder
 #[cfg(feature = "alloc")]
-use alloc::{string::String, vec::Vec};
+use alloc::{string::{String, ToString}, vec::Vec};
 
 use secp256k1::{Message, XOnlyPublicKey};
 use serde_json::{json, Value};

--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -3,8 +3,12 @@
 
 //! Event Id
 
-use std::fmt;
-use std::str::FromStr;
+#[cfg(feature = "std")]
+use std::{fmt, str::FromStr};
+
+#[cfg(feature = "alloc")]
+use alloc::{fmt, str::FromStr, string::String, vec};
+
 
 use bitcoin_hashes::hex::FromHex;
 use bitcoin_hashes::sha256::Hash as Sha256Hash;

--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -27,11 +27,23 @@ use crate::Timestamp;
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
     /// Hex error
-    #[error(transparent)]
-    Hex(#[from] bitcoin_hashes::hex::Error),
+    #[error("Hex Error: {0}")]
+    Hex(bitcoin_hashes::hex::Error),
     /// Hash error
-    #[error(transparent)]
-    Hash(#[from] bitcoin_hashes::Error),
+    #[error("Hash Error: {0}")]
+    Hash(bitcoin_hashes::Error),
+}
+
+impl From<bitcoin_hashes::Error> for Error {
+    fn from(error: bitcoin_hashes::Error) -> Self {
+        Self::Hash(error)
+    }
+}
+
+impl From<bitcoin_hashes::hex::Error> for Error {
+    fn from(error: bitcoin_hashes::hex::Error) -> Self {
+        Self::Hex(error)
+    }
 }
 
 /// Event Id

--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "std")]
 use std::{fmt, str::FromStr};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
     fmt,
     str::FromStr,

--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -7,7 +7,7 @@
 use std::{fmt, str::FromStr};
 
 #[cfg(feature = "alloc")]
-use alloc::{fmt, str::FromStr, string::String, vec};
+use alloc::{fmt, str::FromStr, string::{String, ToString}, vec};
 
 
 use bitcoin_hashes::hex::FromHex;

--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -7,8 +7,12 @@
 use std::{fmt, str::FromStr};
 
 #[cfg(feature = "alloc")]
-use alloc::{fmt, str::FromStr, string::{String, ToString}, vec};
-
+use alloc::{
+    fmt,
+    str::FromStr,
+    string::{String, ToString},
+    vec,
+};
 
 use bitcoin_hashes::hex::FromHex;
 use bitcoin_hashes::sha256::Hash as Sha256Hash;

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -3,13 +3,9 @@
 
 //! Kind
 
-use core::num::ParseIntError;
-
-#[cfg(feature = "alloc")]
-use alloc::{fmt, str::FromStr};
-
-#[cfg(feature = "std")]
-use std::{fmt, str::FromStr};
+use std::fmt;
+use std::num::ParseIntError;
+use std::str::FromStr;
 
 use serde::de::{Deserialize, Deserializer, Error, Visitor};
 use serde::ser::{Serialize, Serializer};

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -3,9 +3,13 @@
 
 //! Kind
 
-use std::fmt;
-use std::num::ParseIntError;
-use std::str::FromStr;
+use core::num::ParseIntError;
+
+#[cfg(feature = "alloc")]
+use alloc::{fmt, str::FromStr};
+
+#[cfg(feature = "std")]
+use std::{fmt, str::FromStr};
 
 use serde::de::{Deserialize, Deserializer, Error, Visitor};
 use serde::ser::{Serialize, Serializer};

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -5,7 +5,7 @@
 
 use core::num::ParseIntError;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{fmt, str::FromStr};
 
 #[cfg(feature = "std")]

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -8,7 +8,11 @@
 use std::str::FromStr;
 
 #[cfg(feature = "alloc")]
-use alloc::{str::FromStr, string::{String, ToString}, vec::Vec};
+use alloc::{
+    str::FromStr,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -15,11 +15,9 @@ use alloc::{
 };
 
 use secp256k1::schnorr::Signature;
-#[cfg(all(feature = "alloc", not(feature = "std")))]
 use secp256k1::Message;
 
 use secp256k1::XOnlyPublicKey;
-#[cfg(all(feature = "alloc", not(feature = "std")))]
 use secp256k1::{Secp256k1, Verification};
 use serde_json::Value;
 
@@ -109,7 +107,7 @@ impl Event {
     }
 
     /// Verify Event
-    #[cfg(not(feature = "std"))]
+    //#[cfg(not(feature = "std"))]
     pub fn verify_with_context<C: Verification>(&self, secp: &Secp256k1<C>) -> Result<(), Error> {
         let id = EventId::new(
             &self.pubkey,

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -42,8 +42,8 @@ pub enum Error {
     #[error("invalid signature")]
     InvalidSignature,
     /// Error serializing or deserializing JSON data
-    #[error(transparent)]
-    Json(#[from] serde_json::Error),
+    #[error("Serde json Error: {0}")]
+    Json(serde_json::Error),
     /// Secp256k1 error
     #[error("Secp256k1 Error: {0}")]
     Secp256k1(secp256k1::Error),
@@ -54,6 +54,12 @@ pub enum Error {
     #[cfg(feature = "nip03")]
     #[error(transparent)]
     OpenTimestamps(#[from] nostr_ots::Error),
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
 }
 
 impl From<secp256k1::Error> for Error {

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -7,7 +7,7 @@
 #[cfg(feature = "std")]
 use std::str::FromStr;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
     str::FromStr,
     string::{String, ToString},
@@ -15,8 +15,11 @@ use alloc::{
 };
 
 use secp256k1::schnorr::Signature;
-use secp256k1::{Message, XOnlyPublicKey};
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use secp256k1::Message;
+
+use secp256k1::XOnlyPublicKey;
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use secp256k1::{Secp256k1, Verification};
 use serde_json::Value;
 

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -8,7 +8,7 @@
 use std::str::FromStr;
 
 #[cfg(feature = "alloc")]
-use alloc::{str::FromStr, string::String, vec::Vec};
+use alloc::{str::FromStr, string::{String, ToString}, vec::Vec};
 
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -29,7 +29,9 @@ pub use self::id::EventId;
 pub use self::kind::Kind;
 pub use self::tag::{Marker, Tag, TagKind};
 pub use self::unsigned::UnsignedEvent;
-use crate::{Timestamp, SECP256K1};
+use crate::Timestamp;
+#[cfg(feature = "std")]
+use crate::SECP256K1;
 
 /// [`Event`] error
 #[derive(Debug, thiserror::Error)]
@@ -77,6 +79,7 @@ pub struct Event {
 
 impl Event {
     /// Verify event
+    #[cfg(feature = "std")]
     pub fn verify(&self) -> Result<(), Error> {
         let id = EventId::new(
             &self.pubkey,
@@ -87,6 +90,21 @@ impl Event {
         );
         let message = Message::from_slice(id.as_bytes())?;
         SECP256K1
+            .verify_schnorr(&self.sig, &message, &self.pubkey)
+            .map_err(|_| Error::InvalidSignature)
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn verify_with_context(&self, context: &impl secp256k1::Verification) -> Result<(), Error> {
+        let id = EventId::new(
+            &self.pubkey,
+            self.created_at,
+            &self.kind,
+            &self.tags,
+            &self.content,
+        );
+        let message = Message::from_slice(id.as_bytes())?;
+        context
             .verify_schnorr(&self.sig, &message, &self.pubkey)
             .map_err(|_| Error::InvalidSignature)
     }

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -75,7 +75,6 @@ impl From<bitcoin_hashes::hex::Error> for Error {
     }
 }
 
-
 /// [`Event`] struct
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Event {
@@ -107,7 +106,6 @@ impl Event {
     }
 
     /// Verify Event
-    //#[cfg(not(feature = "std"))]
     pub fn verify_with_context<C: Verification>(&self, secp: &Secp256k1<C>) -> Result<(), Error> {
         let id = EventId::new(
             &self.pubkey,
@@ -117,8 +115,7 @@ impl Event {
             &self.content,
         );
         let message = Message::from_slice(id.as_bytes())?;
-        secp
-            .verify_schnorr(&self.sig, &message, &self.pubkey)
+        secp.verify_schnorr(&self.sig, &message, &self.pubkey)
             .map_err(|_| Error::InvalidSignature)
     }
 

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -4,7 +4,11 @@
 
 //! Event
 
+#[cfg(feature = "std")]
 use std::str::FromStr;
+
+#[cfg(feature = "alloc")]
+use alloc::{str::FromStr, string::String, vec::Vec};
 
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -45,16 +45,29 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     /// Secp256k1 error
-    #[error(transparent)]
-    Secp256k1(#[from] secp256k1::Error),
+    #[error("Secp256k1 Error: {0}")]
+    Secp256k1(secp256k1::Error),
     /// Hex decoding error
-    #[error(transparent)]
-    Hex(#[from] bitcoin_hashes::hex::Error),
+    #[error("Hex Error: {0}")]
+    Hex(bitcoin_hashes::hex::Error),
     /// OpenTimestamps error
     #[cfg(feature = "nip03")]
     #[error(transparent)]
     OpenTimestamps(#[from] nostr_ots::Error),
 }
+
+impl From<secp256k1::Error> for Error {
+    fn from(error: secp256k1::Error) -> Self {
+        Self::Secp256k1(error)
+    }
+}
+
+impl From<bitcoin_hashes::hex::Error> for Error {
+    fn from(error: bitcoin_hashes::hex::Error) -> Self {
+        Self::Hex(error)
+    }
+}
+
 
 /// [`Event`] struct
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -3,15 +3,20 @@
 
 //! Tag
 
-
 #[cfg(feature = "alloc")]
-use alloc::{fmt, format, str::FromStr, vec, vec::Vec, string::{String, ToString}};
+use alloc::{
+    fmt, format,
+    str::FromStr,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 #[cfg(not(feature = "std"))]
 use core::num::ParseIntError;
 
 #[cfg(feature = "std")]
-use std::{fmt, str::FromStr, num::ParseIntError};
+use std::{fmt, num::ParseIntError, str::FromStr};
 
 use secp256k1::schnorr::Signature;
 use secp256k1::XOnlyPublicKey;

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -3,12 +3,15 @@
 
 //! Tag
 
-#[cfg(feature = "alloc")]
-use alloc::{vec::Vec, string::String};
 
-use std::fmt;
-use std::num::ParseIntError;
-use std::str::FromStr;
+#[cfg(feature = "alloc")]
+use alloc::{fmt, format, str::FromStr, vec, vec::Vec, string::String};
+
+#[cfg(feature = "alloc")]
+use core::num::error::ParseIntError;
+
+#[cfg(feature = "std")]
+use std::{fmt, str::FromStr, num::ParseIntError};
 
 use secp256k1::schnorr::Signature;
 use secp256k1::XOnlyPublicKey;

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -7,8 +7,8 @@
 #[cfg(feature = "alloc")]
 use alloc::{fmt, format, str::FromStr, vec, vec::Vec, string::String};
 
-#[cfg(feature = "alloc")]
-use core::num::error::ParseIntError;
+#[cfg(not(feature = "std"))]
+use core::num::ParseIntError;
 
 #[cfg(feature = "std")]
 use std::{fmt, str::FromStr, num::ParseIntError};

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -5,7 +5,7 @@
 
 
 #[cfg(feature = "alloc")]
-use alloc::{fmt, format, str::FromStr, vec, vec::Vec, string::String};
+use alloc::{fmt, format, str::FromStr, vec, vec::Vec, string::{String, ToString}};
 
 #[cfg(not(feature = "std"))]
 use core::num::ParseIntError;

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -3,9 +3,6 @@
 
 //! Tag
 
-#[cfg(feature = "alloc")]
-use alloc::{vec::Vec, string::String};
-
 use std::fmt;
 use std::num::ParseIntError;
 use std::str::FromStr;

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -48,11 +48,11 @@ pub enum Error {
     #[error(transparent)]
     ParseIntError(#[from] ParseIntError),
     /// Secp256k1
-    #[error(transparent)]
-    Secp256k1(#[from] secp256k1::Error),
+    #[error("Secp256k1 Error: {0}")]
+    Secp256k1(secp256k1::Error),
     /// Hex decoding error
-    #[error(transparent)]
-    Hex(#[from] bitcoin_hashes::hex::Error),
+    #[error("Hex Error: {0}")]
+    Hex(bitcoin_hashes::hex::Error),
     /// Url parse error
     #[error("invalid url")]
     Url(#[from] url::ParseError),
@@ -68,6 +68,18 @@ pub enum Error {
     /// Invalid Zap Request
     #[error("Invalid Zap request")]
     InvalidZapRequest,
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(error: secp256k1::Error) -> Self {
+        Self::Secp256k1(error)
+    }
+}
+
+impl From<bitcoin_hashes::hex::Error> for Error {
+    fn from(error: bitcoin_hashes::hex::Error) -> Self {
+        Self::Hex(error)
+    }
 }
 
 /// Marker

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -3,6 +3,9 @@
 
 //! Tag
 
+#[cfg(feature = "alloc")]
+use alloc::{vec::Vec, string::String};
+
 use std::fmt;
 use std::num::ParseIntError;
 use std::str::FromStr;

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -54,8 +54,8 @@ pub enum Error {
     #[error("Hex Error: {0}")]
     Hex(bitcoin_hashes::hex::Error),
     /// Url parse error
-    #[error("invalid url")]
-    Url(#[from] url::ParseError),
+    #[error("invalid url: {0}")]
+    Url(url::ParseError),
     /// EventId error
     #[error(transparent)]
     EventId(#[from] id::Error),
@@ -79,6 +79,12 @@ impl From<secp256k1::Error> for Error {
 impl From<bitcoin_hashes::hex::Error> for Error {
     fn from(error: bitcoin_hashes::hex::Error) -> Self {
         Self::Hex(error)
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(error: url::ParseError) -> Self {
+        Self::Url(error)
     }
 }
 

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -3,7 +3,7 @@
 
 //! Tag
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
     fmt, format,
     str::FromStr,
@@ -12,7 +12,7 @@ use alloc::{
     vec::Vec,
 };
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use core::num::ParseIntError;
 
 #[cfg(feature = "std")]

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -4,7 +4,7 @@
 //! Unsigned Event
 
 #[cfg(feature = "alloc")]
-use alloc::{string::String, vec::Vec};
+use alloc::{string::{String, ToString}, vec::Vec};
 
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -21,8 +21,8 @@ pub enum Error {
     #[error(transparent)]
     Key(#[from] crate::key::Error),
     /// Error serializing or deserializing JSON data
-    #[error(transparent)]
-    Json(#[from] serde_json::Error),
+    #[error("Serde json Error: {0}")]
+    Json(serde_json::Error),
     /// Secp256k1 error
     #[error("Secp256k1 Error: {0}")]
     Secp256k1(secp256k1::Error),
@@ -34,6 +34,12 @@ pub enum Error {
 impl From<secp256k1::Error> for Error {
     fn from(error: secp256k1::Error) -> Self {
         Self::Secp256k1(error)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
     }
 }
 

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -50,6 +50,7 @@ pub struct UnsignedEvent {
 
 impl UnsignedEvent {
     /// Sign an [`UnsignedEvent`]
+    #[cfg(feature = "std")]
     pub fn sign(self, keys: &Keys) -> Result<Event, Error> {
         let message = Message::from_slice(self.id.as_bytes())?;
         Ok(Event {
@@ -65,7 +66,25 @@ impl UnsignedEvent {
         })
     }
 
+    /// Sign an [`UnsignedEvent`] with specified signature
+    #[cfg(not(feature = "std"))]
+    pub fn sign_with_signature(self, keys: &Keys, sig: Signature) -> Result<Event, Error> {
+        let message = Message::from_slice(self.id.as_bytes())?;
+        Ok(Event {
+            id: self.id,
+            pubkey: self.pubkey,
+            created_at: self.created_at,
+            kind: self.kind,
+            tags: self.tags,
+            content: self.content,
+            sig,
+            #[cfg(feature = "nip03")]
+            ots: None,
+        })
+    }
+
     /// Add signature to [`UnsignedEvent`]
+    #[cfg(feature = "std")]
     pub fn add_signature(self, sig: Signature) -> Result<Event, Error> {
         let event = Event {
             id: self.id,

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -10,9 +10,15 @@ use alloc::{
 };
 
 use secp256k1::schnorr::Signature;
-use secp256k1::{Message, XOnlyPublicKey};
+use secp256k1::XOnlyPublicKey;
 
-use crate::{Event, EventId, Keys, Kind, Tag, Timestamp};
+#[cfg(feature = "std")]
+use secp256k1::Message;
+
+use crate::{Event, EventId, Kind, Tag, Timestamp};
+
+#[cfg(feature = "std")]
+use crate::Keys;
 
 /// [`UnsignedEvent`] error
 #[derive(Debug, thiserror::Error)]

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -3,6 +3,9 @@
 
 //! Unsigned Event
 
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
+
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};
 

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -24,11 +24,17 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     /// Secp256k1 error
-    #[error(transparent)]
-    Secp256k1(#[from] secp256k1::Error),
+    #[error("Secp256k1 Error: {0}")]
+    Secp256k1(secp256k1::Error),
     /// Event error
     #[error(transparent)]
     Event(#[from] super::Error),
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(error: secp256k1::Error) -> Self {
+        Self::Secp256k1(error)
+    }
 }
 
 /// [`UnsignedEvent`] struct

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -4,7 +4,10 @@
 //! Unsigned Event
 
 #[cfg(feature = "alloc")]
-use alloc::{string::{String, ToString}, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, XOnlyPublicKey};

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -10,9 +10,9 @@ use alloc::{
 };
 
 use secp256k1::schnorr::Signature;
-use secp256k1::XOnlyPublicKey;
+use secp256k1::{Message, XOnlyPublicKey};
 
-use crate::{Event, EventId, Kind, Tag, Timestamp};
+use crate::{Event, EventId, Keys, Kind, Tag, Timestamp};
 
 /// [`UnsignedEvent`] error
 #[derive(Debug, thiserror::Error)]

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -10,9 +10,9 @@ use alloc::{
 };
 
 use secp256k1::schnorr::Signature;
-use secp256k1::{Message, XOnlyPublicKey};
+use secp256k1::XOnlyPublicKey;
 
-use crate::{Event, EventId, Keys, Kind, Tag, Timestamp};
+use crate::{Event, EventId, Kind, Tag, Timestamp};
 
 /// [`UnsignedEvent`] error
 #[derive(Debug, thiserror::Error)]
@@ -68,8 +68,7 @@ impl UnsignedEvent {
 
     /// Sign an [`UnsignedEvent`] with specified signature
     #[cfg(not(feature = "std"))]
-    pub fn sign_with_signature(self, keys: &Keys, sig: Signature) -> Result<Event, Error> {
-        let message = Message::from_slice(self.id.as_bytes())?;
+    pub fn sign_with_signature(self, sig: Signature) -> Result<Event, Error> {
         Ok(Event {
             id: self.id,
             pubkey: self.pubkey,

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -94,6 +94,7 @@ impl Keys {
         }
     }
 
+    /// Initialize from secret key.
     #[cfg(not(feature = "std"))]
     pub fn new_with_secp<C: secp256k1::Signing>(
         secret_key: SecretKey,
@@ -126,11 +127,12 @@ impl Keys {
         Self::new(secret_key)
     }
 
+    /// Generate new random [`Keys`]
     #[cfg(not(feature = "std"))]
     pub fn generate_with_secp<C: Signing>(secp: &Secp256k1<C>) -> Self {
         let mut rng = OsRng::default();
         let (secret_key, _) = secp.generate_keypair(&mut rng);
-        Self::new(secret_key)
+        Self::new_with_secp(secret_key, secp)
     }
 
     /// Generate random [`Keys`] with custom [`Rng`]
@@ -143,13 +145,14 @@ impl Keys {
         Self::new(secret_key)
     }
 
+    /// Generate random [`Keys`] with custom [`Rng`] and given [`Secp256k1`]
     #[cfg(not(feature = "std"))]
     pub fn generate_with_rng_with_secp<R, C: Signing>(rng: &mut R, secp: &Secp256k1<C>) -> Self
     where
         R: Rng + ?Sized,
     {
         let (secret_key, _) = secp.generate_keypair(rng);
-        Self::new(secret_key)
+        Self::new_with_secp(secret_key, secp)
     }
 
     /// Generate random [`Keys`] with custom [`Rng`] and without [`KeyPair`]
@@ -241,8 +244,8 @@ impl Keys {
         message: &Message,
         secp: &Secp256k1<C>,
     ) -> Result<Signature, Error> {
-        let keypair: &KeyPair = &self.key_pair()?;
-        Ok(secp.sign_schnorr(message, keypair))
+        let keypair: &KeyPair = &self.key_pair_from_secp(&secp)?;
+        Ok(secp.sign_schnorr_no_aux_rand(message, keypair))
     }
 }
 

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -6,7 +6,9 @@
 //!
 //! This module defines the [`Keys`] structure.
 
-#[cfg(feature = "nip19")]
+#[cfg(all(feature = "alloc", feature = "nip19", not(feature = "std")))]
+use alloc::str::FromStr;
+#[cfg(all(feature = "std", feature = "nip19", not(feature = "alloc")))]
 use std::str::FromStr;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -68,8 +68,15 @@ impl From<secp256k1::Error> for Error {
 pub trait FromSkStr: Sized {
     /// Error
     type Err;
+    #[cfg(all(feature = "std", not(feature = "alloc")))]
     /// Init [`Keys`] from `hex` or `bech32` secret key string
     fn from_sk_str(secret_key: &str) -> Result<Self, Self::Err>;
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    /// Init [`Keys`] from `hex` or `bech32` secret key string
+    fn from_sk_str<C: secp256k1::Signing>(
+        secret_key: &str,
+        secp: &Secp256k1<C>,
+    ) -> Result<Self, Self::Err>;
 }
 
 /// Trait for [`Keys`]
@@ -257,7 +264,7 @@ impl Keys {
     }
 }
 
-#[cfg(feature = "nip19")]
+#[cfg(all(feature = "std", feature = "nip19", not(feature = "alloc")))]
 impl FromSkStr for Keys {
     type Err = Error;
 
@@ -272,7 +279,24 @@ impl FromSkStr for Keys {
         }
     }
 }
+#[cfg(all(feature = "alloc", feature = "nip19", not(feature = "std")))]
+impl FromSkStr for Keys {
+    type Err = Error;
 
+    /// Init [`Keys`] from `hex` or `bech32` secret key
+    fn from_sk_str<C: secp256k1::Signing>(
+        secret_key: &str,
+        secp: &Secp256k1<C>,
+    ) -> Result<Self, Self::Err> {
+        match SecretKey::from_str(secret_key) {
+            Ok(secret_key) => Ok(Self::new_with_secp(secret_key, &secp)),
+            Err(_) => match SecretKey::from_bech32(secret_key) {
+                Ok(secret_key) => Ok(Self::new_with_secp(secret_key, &secp)),
+                Err(_) => Err(Error::InvalidSecretKey),
+            },
+        }
+    }
+}
 #[cfg(feature = "nip19")]
 impl FromPkStr for Keys {
     type Err = Error;

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -20,7 +20,7 @@ use secp256k1::Secp256k1;
 use secp256k1::Signing;
 
 #[cfg(feature = "alloc")]
-use randrand::Rng;
+use rand::Rng;
 #[cfg(feature = "std")]
 use secp256k1::rand::Rng;
 use secp256k1::schnorr::Signature;
@@ -236,7 +236,7 @@ impl Keys {
 
     /// Sign schnorr [`Message`]
     #[cfg(not(feature = "std"))]
-    pub fn sign_schnorr_with_secp<C>(
+    pub fn sign_schnorr_with_secp<C: Signing>(
         &self,
         message: &Message,
         secp: &Secp256k1<C>,

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -9,7 +9,7 @@
 #[cfg(feature = "nip19")]
 use std::str::FromStr;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use rand_core::OsRng;
 #[cfg(feature = "std")]
 use secp256k1::rand::rngs::OsRng;
@@ -19,7 +19,7 @@ use secp256k1::Secp256k1;
 #[cfg(feature = "alloc")]
 use secp256k1::Signing;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use rand::Rng;
 #[cfg(feature = "std")]
 use secp256k1::rand::Rng;

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -52,8 +52,14 @@ pub enum Error {
     #[error("Unsupported char: {0}")]
     InvalidChar(char),
     /// Secp256k1 error
-    #[error(transparent)]
-    Secp256k1(#[from] secp256k1::Error),
+    #[error("Secp256k1 Error: {0}")]
+    Secp256k1(secp256k1::Error),
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(error: secp256k1::Error) -> Self {
+        Self::Secp256k1(error)
+    }
 }
 
 /// Trait for [`Keys`]

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -9,12 +9,25 @@
 #[cfg(feature = "nip19")]
 use std::str::FromStr;
 
+#[cfg(feature = "alloc")]
+use rand_core::OsRng;
+#[cfg(feature = "std")]
 use secp256k1::rand::rngs::OsRng;
+
+#[cfg(feature = "alloc")]
+use secp256k1::Secp256k1;
+#[cfg(feature = "alloc")]
+use secp256k1::Signing;
+
+#[cfg(feature = "alloc")]
+use randrand::Rng;
+#[cfg(feature = "std")]
 use secp256k1::rand::Rng;
 use secp256k1::schnorr::Signature;
 use secp256k1::Message;
 pub use secp256k1::{KeyPair, SecretKey, XOnlyPublicKey};
 
+#[cfg(feature = "std")]
 use crate::SECP256K1;
 
 #[cfg(feature = "vanity")]
@@ -69,8 +82,24 @@ pub struct Keys {
 
 impl Keys {
     /// Initialize from secret key.
+    #[cfg(feature = "std")]
     pub fn new(secret_key: SecretKey) -> Self {
         let key_pair = KeyPair::from_secret_key(SECP256K1, &secret_key);
+        let public_key = XOnlyPublicKey::from_keypair(&key_pair).0;
+
+        Self {
+            public_key,
+            key_pair: Some(key_pair),
+            secret_key: Some(secret_key),
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn new_with_secp<C: secp256k1::Signing>(
+        secret_key: SecretKey,
+        secp: &Secp256k1<C>,
+    ) -> Self {
+        let key_pair = KeyPair::from_secret_key(secp, &secret_key);
         let public_key = XOnlyPublicKey::from_keypair(&key_pair).0;
 
         Self {
@@ -90,13 +119,22 @@ impl Keys {
     }
 
     /// Generate new random [`Keys`]
+    #[cfg(feature = "std")]
     pub fn generate() -> Self {
         let mut rng = OsRng::default();
         let (secret_key, _) = SECP256K1.generate_keypair(&mut rng);
         Self::new(secret_key)
     }
 
+    #[cfg(not(feature = "std"))]
+    pub fn generate_with_secp<C: Signing>(secp: &Secp256k1<C>) -> Self {
+        let mut rng = OsRng::default();
+        let (secret_key, _) = secp.generate_keypair(&mut rng);
+        Self::new(secret_key)
+    }
+
     /// Generate random [`Keys`] with custom [`Rng`]
+    #[cfg(feature = "std")]
     pub fn generate_with_rng<R>(rng: &mut R) -> Self
     where
         R: Rng + ?Sized,
@@ -105,13 +143,42 @@ impl Keys {
         Self::new(secret_key)
     }
 
+    #[cfg(not(feature = "std"))]
+    pub fn generate_with_rng_with_secp<R, C: Signing>(rng: &mut R, secp: &Secp256k1<C>) -> Self
+    where
+        R: Rng + ?Sized,
+    {
+        let (secret_key, _) = secp.generate_keypair(rng);
+        Self::new(secret_key)
+    }
+
     /// Generate random [`Keys`] with custom [`Rng`] and without [`KeyPair`]
     /// Useful for faster [`Keys`] generation (ex. vanity pubkey mining)
+    #[cfg(feature = "std")]
     pub fn generate_without_keypair<R>(rng: &mut R) -> Self
     where
         R: Rng + ?Sized,
     {
         let (secret_key, public_key) = SECP256K1.generate_keypair(rng);
+        let (public_key, _) = public_key.x_only_public_key();
+        Self {
+            public_key,
+            key_pair: None,
+            secret_key: Some(secret_key),
+        }
+    }
+
+    /// Generate random [`Keys`] with custom [`Rng`] and without [`KeyPair`]
+    /// Useful for faster [`Keys`] generation (ex. vanity pubkey mining)
+    #[cfg(not(feature = "std"))]
+    pub fn generate_without_keypair_with_secp<R, C: Signing>(
+        rng: &mut R,
+        secp: &Secp256k1<C>,
+    ) -> Self
+    where
+        R: Rng + ?Sized,
+    {
+        let (secret_key, public_key) = secp.generate_keypair(rng);
         let (public_key, _) = public_key.x_only_public_key();
         Self {
             public_key,
@@ -137,6 +204,7 @@ impl Keys {
     /// Get keypair
     ///
     /// If not exists, will be created
+    #[cfg(feature = "std")]
     pub fn key_pair(&self) -> Result<KeyPair, Error> {
         if let Some(key_pair) = self.key_pair {
             Ok(key_pair)
@@ -146,10 +214,35 @@ impl Keys {
         }
     }
 
+    /// Get keypair
+    ///
+    /// If not exists, will be created
+    #[cfg(not(feature = "std"))]
+    pub fn key_pair_from_secp<C: Signing>(&self, secp: &Secp256k1<C>) -> Result<KeyPair, Error> {
+        if let Some(key_pair) = self.key_pair {
+            Ok(key_pair)
+        } else {
+            let sk = self.secret_key()?;
+            Ok(KeyPair::from_secret_key(secp, &sk))
+        }
+    }
+
     /// Sign schnorr [`Message`]
+    #[cfg(feature = "std")]
     pub fn sign_schnorr(&self, message: &Message) -> Result<Signature, Error> {
         let keypair: &KeyPair = &self.key_pair()?;
         Ok(SECP256K1.sign_schnorr(message, keypair))
+    }
+
+    /// Sign schnorr [`Message`]
+    #[cfg(not(feature = "std"))]
+    pub fn sign_schnorr_with_secp<C>(
+        &self,
+        message: &Message,
+        secp: &Secp256k1<C>,
+    ) -> Result<Signature, Error> {
+        let keypair: &KeyPair = &self.key_pair()?;
+        Ok(secp.sign_schnorr(message, keypair))
     }
 }
 

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -1,10 +1,7 @@
 // Copyright (c) 2022-2023 Yuki Kishimoto
 // Distributed under the MIT software license
 
-
-
 #![cfg_attr(not(feature = "std"), feature(error_in_core))]
-
 #![warn(missing_docs)]
 #![warn(rustdoc::bare_urls)]
 
@@ -14,7 +11,6 @@
     feature = "default",
     doc = include_str!("../README.md")
 )]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -31,9 +31,17 @@ pub use bip39;
 #[cfg(feature = "nip06")]
 pub use bitcoin;
 pub use bitcoin_hashes as hashes;
-pub use secp256k1::{self, SECP256K1};
+pub use secp256k1;
+#[cfg(feature = "std")]
+pub use secp256k1::SECP256K1;
 pub use serde_json;
-pub use url::{self, Url};
+
+#[cfg(feature = "std")]
+pub use url;
+#[cfg(feature = "alloc")]
+extern crate url_no_std as url;
+
+pub use url::Url;
 
 pub mod event;
 pub mod key;

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -38,7 +38,7 @@ pub use serde_json;
 
 #[cfg(feature = "std")]
 pub use url;
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate url_no_std as url;
 
 pub use url::Url;
@@ -59,5 +59,5 @@ pub use self::types::{ChannelId, Contact, Entity, Metadata, Profile, Timestamp};
 #[cfg(feature = "std")]
 pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 /// Result
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 pub type Result<T, E = Box<dyn core::error::Error>> = core::result::Result<T, E>;

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -20,6 +20,9 @@
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
+extern crate thiserror_core as thiserror;
+
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 #[macro_use]
@@ -49,4 +52,7 @@ pub use self::message::{ClientMessage, Filter, RelayMessage, SubscriptionId};
 pub use self::types::{ChannelId, Contact, Entity, Metadata, Profile, Timestamp};
 
 /// Result
+#[cfg(feature = "std")]
 pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+#[cfg(feature = "alloc")]
+pub type Result<T, E = Box<dyn core::error::Error>> = core::result::Result<T, E>;

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -50,5 +50,6 @@ pub use self::types::{ChannelId, Contact, Entity, Metadata, Profile, Timestamp};
 /// Result
 #[cfg(feature = "std")]
 pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+/// Result
 #[cfg(feature = "alloc")]
 pub type Result<T, E = Box<dyn core::error::Error>> = core::result::Result<T, E>;

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -1,10 +1,6 @@
 // Copyright (c) 2022-2023 Yuki Kishimoto
 // Distributed under the MIT software license
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
-#[cfg(not(feature = "debug"))]
-extern crate alloc;
 
 
 
@@ -17,6 +13,14 @@ extern crate alloc;
     feature = "default",
     doc = include_str!("../README.md")
 )]
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 #[macro_use]
 pub extern crate serde;
@@ -45,4 +49,4 @@ pub use self::message::{ClientMessage, Filter, RelayMessage, SubscriptionId};
 pub use self::types::{ChannelId, Contact, Entity, Metadata, Profile, Timestamp};
 
 /// Result
-pub type Result<T, E = alloc::boxed::Box<dyn std::error::Error>> = std::result::Result<T, E>;
+pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -3,6 +3,7 @@
 
 
 
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 #![warn(missing_docs)]
 #![warn(rustdoc::bare_urls)]
@@ -15,7 +16,6 @@
 )]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright (c) 2022-2023 Yuki Kishimoto
 // Distributed under the MIT software license
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "debug"))]
+extern crate alloc;
 
 
 
@@ -13,14 +17,6 @@
     feature = "default",
     doc = include_str!("../README.md")
 )]
-
-#![cfg_attr(not(feature = "std"), no_std)]
-
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
 
 #[macro_use]
 pub extern crate serde;
@@ -49,4 +45,4 @@ pub use self::message::{ClientMessage, Filter, RelayMessage, SubscriptionId};
 pub use self::types::{ChannelId, Contact, Entity, Metadata, Profile, Timestamp};
 
 /// Result
-pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+pub type Result<T, E = alloc::boxed::Box<dyn std::error::Error>> = std::result::Result<T, E>;

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -1,6 +1,13 @@
 // Copyright (c) 2022-2023 Yuki Kishimoto
 // Distributed under the MIT software license
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "debug"))]
+extern crate alloc;
+
+
+
 #![warn(missing_docs)]
 #![warn(rustdoc::bare_urls)]
 
@@ -38,4 +45,4 @@ pub use self::message::{ClientMessage, Filter, RelayMessage, SubscriptionId};
 pub use self::types::{ChannelId, Contact, Entity, Metadata, Profile, Timestamp};
 
 /// Result
-pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+pub type Result<T, E = alloc::boxed::Box<dyn std::error::Error>> = std::result::Result<T, E>;

--- a/crates/nostr/src/message/client.rs
+++ b/crates/nostr/src/message/client.rs
@@ -4,6 +4,9 @@
 
 //! Client messages
 
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec, vec::Vec};
+
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};

--- a/crates/nostr/src/message/client.rs
+++ b/crates/nostr/src/message/client.rs
@@ -5,7 +5,7 @@
 //! Client messages
 
 #[cfg(feature = "alloc")]
-use alloc::{string::String, vec, vec::Vec};
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/nostr/src/message/client.rs
+++ b/crates/nostr/src/message/client.rs
@@ -5,7 +5,12 @@
 //! Client messages
 
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, string::{String, ToString}, vec, vec::Vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/nostr/src/message/client.rs
+++ b/crates/nostr/src/message/client.rs
@@ -4,9 +4,6 @@
 
 //! Client messages
 
-#[cfg(feature = "alloc")]
-use alloc::{string::String, vec, vec::Vec};
-
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};

--- a/crates/nostr/src/message/client.rs
+++ b/crates/nostr/src/message/client.rs
@@ -5,7 +5,7 @@
 //! Client messages
 
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, string::String, vec, vec::Vec};
+use alloc::{boxed::Box, string::{String, ToString}, vec, vec::Vec};
 
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/nostr/src/message/mod.rs
+++ b/crates/nostr/src/message/mod.rs
@@ -18,9 +18,15 @@ pub enum MessageHandleError {
     #[error("Message has an invalid format")]
     InvalidMessageFormat,
     /// Impossible to deserialize message
-    #[error("Json deserialization failed: {0}")]
-    Json(#[from] serde_json::Error),
+    #[error("Serde json Error: {0}")]
+    Json(serde_json::Error),
     /// Event error
     #[error(transparent)]
     Event(#[from] crate::event::Error),
+}
+
+impl From<serde_json::Error> for MessageHandleError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
 }

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -4,6 +4,9 @@
 
 //! Relay messages
 
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -5,7 +5,7 @@
 //! Relay messages
 
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, string::String, vec};
+use alloc::{boxed::Box, string::{String, ToString}, vec};
 
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -5,7 +5,11 @@
 //! Relay messages
 
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, string::{String, ToString}, vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec,
+};
 
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -5,7 +5,7 @@
 //! Relay messages
 
 #[cfg(feature = "alloc")]
-use alloc::string::String;
+use alloc::{boxed::Box, string::String, vec};
 
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -4,9 +4,6 @@
 
 //! Relay messages
 
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};

--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -6,11 +6,7 @@
 
 #![allow(missing_docs)]
 
-#[cfg(feature = "std")]
 use std::fmt;
-
-#[cfg(feature = "alloc")]
-use alloc::{fmt, vec::Vec, string::String};
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use bitcoin_hashes::Hash;

--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -10,7 +10,7 @@
 use std::fmt;
 
 #[cfg(feature = "alloc")]
-use alloc::{fmt, vec::Vec, string::String};
+use alloc::{fmt, vec, vec::Vec, string::{String, ToString}};
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use bitcoin_hashes::Hash;

--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -9,7 +9,7 @@
 #[cfg(feature = "std")]
 use std::fmt;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
     fmt,
     string::{String, ToString},
@@ -19,7 +19,7 @@ use alloc::{
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use bitcoin_hashes::Hash;
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use rand_core::{OsRng, RngCore};
 #[cfg(feature = "std")]
 use secp256k1::rand::{rngs::OsRng, RngCore};

--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -19,8 +19,10 @@ use alloc::{
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use bitcoin_hashes::Hash;
-use secp256k1::rand::rngs::OsRng;
-use secp256k1::rand::RngCore;
+#[cfg(feature = "alloc")]
+use rand_core::{OsRng, RngCore};
+#[cfg(feature = "std")]
+use secp256k1::rand::{rngs::OsRng, RngCore};
 use secp256k1::XOnlyPublicKey;
 use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, Serializer};

--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -6,7 +6,11 @@
 
 #![allow(missing_docs)]
 
+#[cfg(feature = "std")]
 use std::fmt;
+
+#[cfg(feature = "alloc")]
+use alloc::{fmt, vec::Vec, string::String};
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use bitcoin_hashes::Hash;

--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -10,7 +10,12 @@
 use std::fmt;
 
 #[cfg(feature = "alloc")]
-use alloc::{fmt, vec, vec::Vec, string::{String, ToString}};
+use alloc::{
+    fmt,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use bitcoin_hashes::Hash;

--- a/crates/nostr/src/nips/nip13.rs
+++ b/crates/nostr/src/nips/nip13.rs
@@ -6,6 +6,9 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/13.md>
 
+#[cfg(feature = "alloc")]
+use alloc::{format, string::String, vec, vec::Vec};
+
 /// Gets the number of leading zero bits. Result is between 0 and 255.
 pub fn get_leading_zero_bits<T>(h: T) -> u8
 where

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -42,8 +42,8 @@ pub enum Error {
     #[error("wrong prefix or variant")]
     WrongPrefixOrVariant,
     /// Bech32 error.
-    #[error(transparent)]
-    Bech32(#[from] bech32::Error),
+    #[error("Bech32 Error: {0}")]
+    Bech32(bech32::Error),
     /// Field missing
     #[error("field missing: {0}")]
     FieldMissing(String),
@@ -76,6 +76,12 @@ impl From<secp256k1::Error> for Error {
 impl From<bitcoin_hashes::Error> for Error {
     fn from(error: bitcoin_hashes::Error) -> Self {
         Self::Hash(error)
+    }
+}
+
+impl From<bech32::Error> for Error {
+    fn from(error: bech32::Error) -> Self {
+        Self::Bech32(error)
     }
 }
 

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -7,6 +7,11 @@
 
 #![allow(missing_docs)]
 
+#[cfg(not(feature = "std"))]
+use alloc::{string::{self, ToString}, vec::Vec};
+#[cfg(feature = "std")]
+use std::string;
+
 use bech32::{self, FromBase32, ToBase32, Variant};
 use secp256k1::{SecretKey, XOnlyPublicKey};
 
@@ -43,7 +48,7 @@ pub enum Error {
     TLV,
     /// UFT-8 error
     #[error(transparent)]
-    UTF8(#[from] std::string::FromUtf8Error),
+    UTF8(#[from] string::FromUtf8Error),
     /// From slice error
     #[error("impossible to perform conversion from slice")]
     TryFromSlice,

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -8,7 +8,11 @@
 #![allow(missing_docs)]
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::{self, ToString}, vec::Vec};
+use alloc::{
+    string::{self, String, ToString},
+    vec,
+    vec::Vec,
+};
 #[cfg(feature = "std")]
 use std::string;
 
@@ -53,15 +57,26 @@ pub enum Error {
     #[error("impossible to perform conversion from slice")]
     TryFromSlice,
     /// Secp256k1 error
-    #[error(transparent)]
-    Secp256k1(#[from] secp256k1::Error),
+    #[error("Secp256k1 Error: {0}")]
+    Secp256k1(secp256k1::Error),
     /// Hash error
-    #[error(transparent)]
-    Hash(#[from] bitcoin_hashes::Error),
+    #[error("Hash Error: {0}")]
+    Hash(bitcoin_hashes::Error),
     /// EventId error
 
     #[error(transparent)]
     EventId(#[from] id::Error),
+}
+impl From<secp256k1::Error> for Error {
+    fn from(error: secp256k1::Error) -> Self {
+        Self::Secp256k1(error)
+    }
+}
+
+impl From<bitcoin_hashes::Error> for Error {
+    fn from(error: bitcoin_hashes::Error) -> Self {
+        Self::Hash(error)
+    }
 }
 
 pub trait FromBech32: Sized {

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -5,7 +5,13 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/26.md>
 #[cfg(feature = "alloc")]
-use alloc::{fmt, format, str::FromStr, string::{String, ToString}, vec, vec::Vec};
+use alloc::{
+    fmt, format,
+    str::FromStr,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 #[cfg(not(feature = "std"))]
 use core::num;

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -4,7 +4,7 @@
 //! NIP26
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/26.md>
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
     fmt, format,
     str::FromStr,
@@ -13,7 +13,7 @@ use alloc::{
     vec::Vec,
 };
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use core::num;
 
 #[cfg(feature = "std")]

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -45,8 +45,8 @@ pub enum Error {
     #[error(transparent)]
     Key(#[from] key::Error),
     /// Secp256k1 error
-    #[error(transparent)]
-    Secp256k1(#[from] secp256k1::Error),
+    #[error("Secp256k1 Error: {0}")]
+    Secp256k1(secp256k1::Error),
     /// Invalid condition in conditions string
     #[error("Invalid condition in conditions string")]
     ConditionsParseInvalidCondition,
@@ -59,6 +59,12 @@ pub enum Error {
     /// Delegation tag parse error
     #[error("Delegation tag parse error")]
     DelegationTagParse,
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(error: secp256k1::Error) -> Self {
+        Self::Secp256k1(error)
+    }
 }
 
 /// Tag validation errors

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -34,7 +34,7 @@ use crate::key::{self, Keys};
 use crate::SECP256K1;
 
 #[cfg(not(feature = "std"))]
-use secp256k1::{Secp256k1, Signing};
+use secp256k1::{Secp256k1, Signing, Verification};
 
 const DELEGATION_KEYWORD: &str = "delegation";
 
@@ -80,6 +80,7 @@ pub enum ValidationError {
 
 /// Sign delegation.
 /// See `create_delegation_tag` for more complete functionality.
+#[cfg(feature = "std")]
 pub fn sign_delegation(
     delegator_keys: &Keys,
     delegatee_pk: XOnlyPublicKey,
@@ -89,6 +90,18 @@ pub fn sign_delegation(
     let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
     let message = Message::from_slice(&hashed_token)?;
     Ok(delegator_keys.sign_schnorr(&message)?)
+}
+#[cfg(not(feature = "std"))]
+pub fn sign_delegation_with_signer<C: Signing>(
+    delegator_keys: &Keys,
+    delegatee_pk: XOnlyPublicKey,
+    conditions: Conditions,
+    secp: &Secp256k1<C>,
+) -> Result<Signature, Error> {
+    let unhashed_token = DelegationToken::new(delegatee_pk, conditions);
+    let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
+    let message = Message::from_slice(&hashed_token)?;
+    Ok(delegator_keys.sign_schnorr_with_secp(&message, secp)?)
 }
 
 /// Verify delegation signature
@@ -108,7 +121,7 @@ pub fn verify_delegation_signature(
 
 /// Verify delegation signature
 #[cfg(not(feature = "std"))]
-pub fn verify_delegation_signature<C: Signing>(
+pub fn verify_delegation_signature<C: Verification>(
     delegator_public_key: XOnlyPublicKey,
     signature: Signature,
     delegatee_public_key: XOnlyPublicKey,
@@ -157,12 +170,37 @@ pub struct DelegationTag {
 impl DelegationTag {
     /// Create a delegation tag (including the signature).
     /// See also validate().
+    #[cfg(feature = "std")]
     pub fn new(
         delegator_keys: &Keys,
         delegatee_pubkey: XOnlyPublicKey,
         conditions: Conditions,
     ) -> Result<Self, Error> {
         let signature = sign_delegation(delegator_keys, delegatee_pubkey, conditions.clone())?;
+        Ok(Self {
+            delegator_pubkey: delegator_keys.public_key(),
+            conditions,
+            signature,
+        })
+    }
+
+    /// Create a delegation tag (including the signature).
+    /// See also validate().
+    #[cfg(not(feature = "std"))]
+    pub fn new<C>(
+        delegator_keys: &Keys,
+        delegatee_pubkey: XOnlyPublicKey,
+        conditions: Conditions,
+        signer: Secp256k1<C>,
+    ) -> Result<Self, Error> {
+        use secp256k1::Secp256k1;
+
+        let signature = sign_delegation_with_signer(
+            delegator_keys,
+            delegatee_pubkey,
+            conditions.clone(),
+            signer,
+        )?;
         Ok(Self {
             delegator_pubkey: delegator_keys.public_key(),
             conditions,
@@ -186,6 +224,7 @@ impl DelegationTag {
     }
 
     /// Validate a delegation tag, check signature and conditions.
+    #[cfg(feature = "std")]
     pub fn validate(
         &self,
         delegatee_pubkey: XOnlyPublicKey,
@@ -197,6 +236,30 @@ impl DelegationTag {
             self.signature,
             delegatee_pubkey,
             self.conditions.clone(),
+        )
+        .map_err(|_| Error::ConditionsValidation(ValidationError::InvalidSignature))?;
+
+        // validate conditions
+        self.conditions.evaluate(event_properties)?;
+
+        Ok(())
+    }
+    /// Validate a delegation tag, check signature and conditions.
+    #[cfg(not(feature = "std"))]
+    pub fn validate<C: Verification>(
+        &self,
+        delegatee_pubkey: XOnlyPublicKey,
+        event_properties: &EventProperties,
+        secp: &Secp256k1<C>,
+    ) -> Result<(), Error> {
+        // verify signature
+
+        verify_delegation_signature(
+            self.delegator_pubkey,
+            self.signature,
+            delegatee_pubkey,
+            self.conditions.clone(),
+            secp,
         )
         .map_err(|_| Error::ConditionsValidation(ValidationError::InvalidSignature))?;
 

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -29,7 +29,12 @@ use serde_json::{json, Value};
 
 use crate::event::Event;
 use crate::key::{self, Keys};
+
+#[cfg(feature = "std")]
 use crate::SECP256K1;
+
+#[cfg(not(feature = "std"))]
+use secp256k1::{Secp256k1, Signing};
 
 const DELEGATION_KEYWORD: &str = "delegation";
 
@@ -87,6 +92,7 @@ pub fn sign_delegation(
 }
 
 /// Verify delegation signature
+#[cfg(feature = "std")]
 pub fn verify_delegation_signature(
     delegator_public_key: XOnlyPublicKey,
     signature: Signature,
@@ -97,6 +103,22 @@ pub fn verify_delegation_signature(
     let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
     let message = Message::from_slice(&hashed_token)?;
     SECP256K1.verify_schnorr(&signature, &message, &delegator_public_key)?;
+    Ok(())
+}
+
+/// Verify delegation signature
+#[cfg(not(feature = "std"))]
+pub fn verify_delegation_signature<C: Signing>(
+    delegator_public_key: XOnlyPublicKey,
+    signature: Signature,
+    delegatee_public_key: XOnlyPublicKey,
+    conditions: Conditions,
+    secp: &Secp256k1<C>,
+) -> Result<(), Error> {
+    let unhashed_token = DelegationToken::new(delegatee_public_key, conditions);
+    let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
+    let message = Message::from_slice(&hashed_token)?;
+    secp.verify_schnorr(&signature, &message, &delegator_public_key)?;
     Ok(())
 }
 

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -4,9 +4,14 @@
 //! NIP26
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/26.md>
+#[cfg(feature = "alloc")]
+use alloc::{fmt, format, str::FromStr, string::{String, ToString}, vec, vec::Vec};
 
-use std::fmt;
-use std::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::num;
+
+#[cfg(feature = "std")]
+use std::{fmt, num, str::FromStr};
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use bitcoin_hashes::Hash;
@@ -36,7 +41,7 @@ pub enum Error {
     ConditionsParseInvalidCondition,
     /// Invalid condition, cannot parse expected number
     #[error("Invalid condition, cannot parse expected number")]
-    ConditionsParseNumeric(#[from] std::num::ParseIntError),
+    ConditionsParseNumeric(#[from] num::ParseIntError),
     /// Conditions not satisfied
     #[error("Conditions not satisfied")]
     ConditionsValidation(#[from] ValidationError),

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -91,6 +91,9 @@ pub fn sign_delegation(
     let message = Message::from_slice(&hashed_token)?;
     Ok(delegator_keys.sign_schnorr(&message)?)
 }
+
+/// Sign delegation.
+/// See `create_delegation_tag` for more complete functionality.
 #[cfg(not(feature = "std"))]
 pub fn sign_delegation_with_signer<C: Signing>(
     delegator_keys: &Keys,
@@ -187,19 +190,17 @@ impl DelegationTag {
     /// Create a delegation tag (including the signature).
     /// See also validate().
     #[cfg(not(feature = "std"))]
-    pub fn new<C>(
+    pub fn new<C: Signing>(
         delegator_keys: &Keys,
         delegatee_pubkey: XOnlyPublicKey,
         conditions: Conditions,
         signer: Secp256k1<C>,
     ) -> Result<Self, Error> {
-        use secp256k1::Secp256k1;
-
         let signature = sign_delegation_with_signer(
             delegator_keys,
             delegatee_pubkey,
             conditions.clone(),
-            signer,
+            &signer,
         )?;
         Ok(Self {
             delegator_pubkey: delegator_keys.public_key(),

--- a/crates/nostr/src/nips/nip65.rs
+++ b/crates/nostr/src/nips/nip65.rs
@@ -2,6 +2,9 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/65.md>
 
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
+
 use crate::Event;
 
 /// Extracts the relay info (url, optional read/write flag) from the event

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -5,7 +5,7 @@
 
 // External crates
 #[cfg(feature = "nip19")]
-pub use bech32::*;
+pub use bech32;
 #[cfg(feature = "nip06")]
 pub use bip39::*;
 #[cfg(feature = "nip06")]
@@ -36,7 +36,7 @@ pub use crate::nips::nip06::*;
 pub use crate::nips::nip11::*;
 pub use crate::nips::nip13::*;
 #[cfg(feature = "nip19")]
-pub use crate::nips::nip19::*;
+pub use crate::nips::nip19;
 pub use crate::nips::nip26::*;
 #[cfg(feature = "nip46")]
 pub use crate::nips::nip46::*;

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -20,7 +20,10 @@ pub use crate::event::*;
 pub use crate::key::*;
 pub use crate::message::*;
 pub use crate::types::*;
-pub use crate::{Result, SECP256K1};
+pub use crate::Result;
+
+#[cfg(feature = "std")]
+pub use crate::SECP256K1;
 
 // NIPs
 #[cfg(feature = "nip04")]

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -8,7 +8,7 @@
 pub use bech32;
 #[cfg(feature = "nip06")]
 pub use bip39::*;
-pub use secp256k1::*;
+pub use secp256k1;
 pub use url::*;
 
 // Internal modules

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -9,17 +9,17 @@ pub use bech32::*;
 #[cfg(feature = "nip06")]
 pub use bip39::*;
 #[cfg(feature = "nip06")]
-pub use bitcoin::*;
-pub use bitcoin_hashes::*;
+//pub use bitcoin::*;
+//pub use bitcoin_hashes::*;
 pub use secp256k1::*;
-pub use serde_json::*;
+//pub use serde_json::*;
 pub use url::*;
 
 // Internal modules
-pub use crate::event::*;
-pub use crate::key::*;
-pub use crate::message::*;
-pub use crate::types::*;
+//pub use crate::event::*;
+//pub use crate::key::*;
+//pub use crate::message::*;
+//pub use crate::types::*;
 pub use crate::Result;
 
 #[cfg(feature = "std")]

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -8,18 +8,10 @@
 pub use bech32;
 #[cfg(feature = "nip06")]
 pub use bip39::*;
-#[cfg(feature = "nip06")]
-//pub use bitcoin::*;
-//pub use bitcoin_hashes::*;
 pub use secp256k1::*;
-//pub use serde_json::*;
 pub use url::*;
 
 // Internal modules
-//pub use crate::event::*;
-//pub use crate::key::*;
-//pub use crate::message::*;
-//pub use crate::types::*;
 pub use crate::Result;
 
 #[cfg(feature = "std")]

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -30,11 +30,23 @@ use crate::EventId;
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
     /// Hex error
-    #[error(transparent)]
-    Hex(#[from] bitcoin_hashes::hex::Error),
+    #[error("Hex Error: {0}")]
+    Hex(bitcoin_hashes::hex::Error),
     /// Hash error
-    #[error(transparent)]
-    Hash(#[from] bitcoin_hashes::Error),
+    #[error("Hash Error: {0}")]
+    Hash(bitcoin_hashes::Error),
+}
+
+impl From<bitcoin_hashes::Error> for Error {
+    fn from(error: bitcoin_hashes::Error) -> Self {
+        Self::Hash(error)
+    }
+}
+
+impl From<bitcoin_hashes::hex::Error> for Error {
+    fn from(error: bitcoin_hashes::hex::Error) -> Self {
+        Self::Hex(error)
+    }
 }
 
 /// Channel Id

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -4,7 +4,7 @@
 //! Channel Id
 
 #[cfg(feature = "alloc")]
-use alloc::{vec::Vec, string::String};
+use alloc::{vec::Vec, string::{String, ToString}};
 
 #[cfg(feature = "alloc")]
 use alloc::fmt;

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -3,9 +3,6 @@
 
 //! Channel Id
 
-#[cfg(feature = "alloc")]
-use alloc::{vec::Vec, string::String};
-
 use std::fmt;
 
 #[cfg(feature = "nip19")]

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -153,6 +153,9 @@ impl FromBech32 for ChannelId {
     }
 }
 
+#[cfg(all(feature = "nip19", feature = "alloc", not(feature = "std")))]
+use alloc::vec;
+
 #[cfg(feature = "nip19")]
 impl ToBech32 for ChannelId {
     type Err = Bech32Error;

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -6,6 +6,9 @@
 #[cfg(feature = "alloc")]
 use alloc::{vec::Vec, string::String};
 
+#[cfg(feature = "alloc")]
+use alloc::fmt;
+#[cfg(feature = "std")]
 use std::fmt;
 
 #[cfg(feature = "nip19")]

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -3,6 +3,9 @@
 
 //! Channel Id
 
+#[cfg(feature = "alloc")]
+use alloc::{vec::Vec, string::String};
+
 use std::fmt;
 
 #[cfg(feature = "nip19")]

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -3,13 +3,13 @@
 
 //! Channel Id
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::fmt;
 #[cfg(feature = "std")]
 use std::fmt;

--- a/crates/nostr/src/types/channel_id.rs
+++ b/crates/nostr/src/types/channel_id.rs
@@ -4,7 +4,10 @@
 //! Channel Id
 
 #[cfg(feature = "alloc")]
-use alloc::{vec::Vec, string::{String, ToString}};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 #[cfg(feature = "alloc")]
 use alloc::fmt;

--- a/crates/nostr/src/types/contact.rs
+++ b/crates/nostr/src/types/contact.rs
@@ -3,9 +3,6 @@
 
 //! Contact
 
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-
 use secp256k1::XOnlyPublicKey;
 
 /// Contact

--- a/crates/nostr/src/types/contact.rs
+++ b/crates/nostr/src/types/contact.rs
@@ -3,6 +3,9 @@
 
 //! Contact
 
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
 use secp256k1::XOnlyPublicKey;
 
 /// Contact

--- a/crates/nostr/src/types/metadata.rs
+++ b/crates/nostr/src/types/metadata.rs
@@ -6,7 +6,7 @@
 use url::Url;
 
 #[cfg(feature = "alloc")]
-use alloc::string::String;
+use alloc::string::{String, ToString};
 
 /// [`Metadata`] error
 #[derive(Debug, thiserror::Error)]

--- a/crates/nostr/src/types/metadata.rs
+++ b/crates/nostr/src/types/metadata.rs
@@ -5,6 +5,8 @@
 
 use url::Url;
 
+use alloc::string::String;
+
 /// [`Metadata`] error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/crates/nostr/src/types/metadata.rs
+++ b/crates/nostr/src/types/metadata.rs
@@ -5,6 +5,7 @@
 
 use url::Url;
 
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 
 /// [`Metadata`] error

--- a/crates/nostr/src/types/metadata.rs
+++ b/crates/nostr/src/types/metadata.rs
@@ -5,7 +5,6 @@
 
 use url::Url;
 
-#[cfg(feature = "alloc")]
 use alloc::string::String;
 
 /// [`Metadata`] error

--- a/crates/nostr/src/types/metadata.rs
+++ b/crates/nostr/src/types/metadata.rs
@@ -12,8 +12,14 @@ use alloc::string::{String, ToString};
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error serializing or deserializing JSON data
-    #[error("json error: {0}")]
-    Json(#[from] serde_json::Error),
+    #[error("Serde json Error: {0}")]
+    Json(serde_json::Error),
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
 }
 
 /// Metadata

--- a/crates/nostr/src/types/profile.rs
+++ b/crates/nostr/src/types/profile.rs
@@ -3,11 +3,11 @@
 
 //! Profile
 
+#[cfg(all(feature = "nip19", feature = "alloc"))]
+use alloc::string::ToString;
 #[cfg(feature = "nip19")]
 use bech32::{self, FromBase32, ToBase32, Variant};
 use secp256k1::XOnlyPublicKey;
-#[cfg(all(feature = "nip19", feature = "alloc"))]
-use alloc::string::ToString;
 
 #[cfg(feature = "nip19")]
 use crate::nips::nip19::{Error, FromBech32, ToBech32, PREFIX_BECH32_PROFILE, RELAY, SPECIAL};
@@ -84,6 +84,8 @@ impl FromBech32 for Profile {
     }
 }
 
+#[cfg(all(feature = "nip19", feature = "alloc"))]
+use alloc::vec;
 #[cfg(feature = "nip19")]
 impl ToBech32 for Profile {
     type Err = Error;

--- a/crates/nostr/src/types/profile.rs
+++ b/crates/nostr/src/types/profile.rs
@@ -9,9 +9,8 @@ use secp256k1::XOnlyPublicKey;
 
 #[cfg(feature = "nip19")]
 use crate::nips::nip19::{Error, FromBech32, ToBech32, PREFIX_BECH32_PROFILE, RELAY, SPECIAL};
-
-#[cfg(feature = "alloc")]
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
+use alloc::string::String;
 
 /// Profile
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]

--- a/crates/nostr/src/types/profile.rs
+++ b/crates/nostr/src/types/profile.rs
@@ -9,6 +9,8 @@ use secp256k1::XOnlyPublicKey;
 
 #[cfg(feature = "nip19")]
 use crate::nips::nip19::{Error, FromBech32, ToBech32, PREFIX_BECH32_PROFILE, RELAY, SPECIAL};
+use alloc::vec::Vec;
+use alloc::string::String;
 
 /// Profile
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]

--- a/crates/nostr/src/types/profile.rs
+++ b/crates/nostr/src/types/profile.rs
@@ -9,8 +9,9 @@ use secp256k1::XOnlyPublicKey;
 
 #[cfg(feature = "nip19")]
 use crate::nips::nip19::{Error, FromBech32, ToBech32, PREFIX_BECH32_PROFILE, RELAY, SPECIAL};
-use alloc::vec::Vec;
-use alloc::string::String;
+
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
 
 /// Profile
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]

--- a/crates/nostr/src/types/profile.rs
+++ b/crates/nostr/src/types/profile.rs
@@ -6,6 +6,8 @@
 #[cfg(feature = "nip19")]
 use bech32::{self, FromBase32, ToBase32, Variant};
 use secp256k1::XOnlyPublicKey;
+#[cfg(all(feature = "nip19", feature = "alloc"))]
+use alloc::string::ToString;
 
 #[cfg(feature = "nip19")]
 use crate::nips::nip19::{Error, FromBech32, ToBech32, PREFIX_BECH32_PROFILE, RELAY, SPECIAL};

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -13,9 +13,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::fmt;
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use core::num;
 
 #[cfg(target_arch = "wasm32")]
@@ -81,12 +81,20 @@ use std::time::Instant;
 #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
 impl TimeSupplier for Instant {
     type Now = Instant;
+    type StartingPoint = std::time::SystemTime;
 
     fn now(&self) -> Self::Now {
         Instant::now()
     }
 
+    fn starting_point(&self) -> Self::StartingPoint {
+        std::time::UNIX_EPOCH
+    }
+
     fn elapsed_since(&self, now: Self::Now, since: Self::Now) -> Duration {
+        now - since
+    }
+    fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration {
         now - since
     }
 

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -43,12 +43,6 @@ pub trait TimeSupplier {
     fn elapsed_instant_since(&self, now: Self::Now, since: Self::Now) -> Duration;
     /// Get the elapsed time as `Duration` starting from `since` to `now`
     fn elapsed_since(&self, now: Self::StartingPoint, since: Self::StartingPoint) -> Duration;
-
-    //  /// Get the elapsed time as `Duration` starting from `since` to `now`
-    //  /// This is the specialised case for handling the `StartingPoint` in case its type is different
-    //  /// than the `Now` type.
-    //  fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration;
-
     /// Convert the specified `Duration` to `i64`
     fn as_i64(&self, duration: Duration) -> i64;
     /// Convert the specified `Duration` to `Timestamp`
@@ -99,7 +93,8 @@ impl TimeSupplier for Instant {
     }
 
     fn duration_since_starting_point(&self, now: Self::StartingPoint) -> Duration {
-        now.duration_since(self.starting_point()).expect("duration_since panicked")
+        now.duration_since(self.starting_point())
+            .expect("duration_since panicked")
     }
 
     fn starting_point(&self) -> Self::StartingPoint {
@@ -114,11 +109,6 @@ impl TimeSupplier for Instant {
         now.duration_since(since).expect("duration_since panicked")
     }
 
-//     fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration {
-//         let dur = since.duration_since(self.starting_point).expect("Clock may have gone backwards");
-//         now - since
-//     }
-// 
     fn as_i64(&self, duration: Duration) -> i64 {
         duration.as_millis() as i64
     }

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -151,7 +151,7 @@ impl Timestamp {
     {
         let now = time_supplier.now();
         let starting_point = time_supplier.starting_point();
-        let duration = time_supplier.elapsed_duration(now, starting_point);
+        let duration = time_supplier.elapsed_since(now, starting_point);
 
         time_supplier.to_timestamp(duration)
     }

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -11,7 +11,7 @@ use core::str::FromStr;
 use std::{fmt, num, time::{SystemTime, UNIX_EPOCH}};
 
 #[cfg(feature = "alloc")]
-use alloc::{fmt, vec::Vec, string::String};
+use alloc::fmt;
 #[cfg(feature = "alloc")]
 use core::num;
 

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -26,16 +26,16 @@ const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 
 /// Helper trait for acquiring time in `no_std` environments.
 pub trait TimeSupplier {
-    type Now;
+    type Now: Clone;
     type StartingPoint;
 
     fn now(&self) -> Self::Now;
     fn starting_point(&self) -> Self::StartingPoint;
-    fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration;
-    fn elapsed_duration(now: Self::Now, since: Self::StartingPoint) -> Duration;
+    fn elapsed_since(&self, now: Self::Now, since: Self::Now) -> Duration;
+    fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration;
 
-    fn as_i64(duration: Duration) -> i64;
-    fn to_timestamp(duration: Duration) -> Timestamp;
+    fn as_i64(&self, duration: Duration) -> i64;
+    fn to_timestamp(&self, duration: Duration) -> Timestamp;
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -53,15 +53,15 @@ impl TimeSupplier for InstantWasm32 {
         std::time::UNIX_EPOCH
     }
 
-    fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration {
+    fn elapsed_since(&self, now: Self::Now, since: Self::Now) -> Duration {
         now - since
     }
 
-    fn as_i64(duration: Duration) -> i64 {
+    fn as_i64(&self, duration: Duration) -> i64 {
         duration.as_millis() as i64
     }
 
-    fn to_timestamp(duration: Duration) -> Timestamp {
+    fn to_timestamp(&self, duration: Duration) -> Timestamp {
         Timestamp(duration.as_millis() as i64)
     }
 }
@@ -76,15 +76,15 @@ impl TimeSupplier for Instant {
         Instant::now()
     }
 
-    fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration {
+    fn elapsed_since(&self, now: Self::Now, since: Self::Now) -> Duration {
         now - since
     }
 
-    fn as_i64(duration: Duration) -> i64 {
+    fn as_i64(&self, duration: Duration) -> i64 {
         duration.as_millis() as i64
     }
 
-    fn to_timestamp(duration: Duration) -> Timestamp {
+    fn to_timestamp(&self, duration: Duration) -> Timestamp {
         Timestamp(duration.as_i64())
     }
 }
@@ -111,9 +111,9 @@ impl Timestamp {
     {
         let now = time_supplier.now();
         let starting_point = time_supplier.starting_point();
-        let duration = <T as TimeSupplier>::elapsed_duration(now, starting_point);
+        let duration = time_supplier.elapsed_duration(now, starting_point);
 
-        <T as TimeSupplier>::to_timestamp(duration)
+        time_supplier.to_timestamp(duration)
     }
 
     /// Get timestamp as [`u64`]

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -26,15 +26,25 @@ const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 
 /// Helper trait for acquiring time in `no_std` environments.
 pub trait TimeSupplier {
+    /// The current time from the specified `TimeSupplier`
     type Now: Clone;
+    /// The starting point for the specified `TimeSupplier`
     type StartingPoint;
 
+    /// Get the current time as the associated `Now` type
     fn now(&self) -> Self::Now;
+    /// Get the starting point from the specified `TimeSupplier`
     fn starting_point(&self) -> Self::StartingPoint;
+    /// Get the elapsed time as `Duration` starting from `since` to `now`
     fn elapsed_since(&self, now: Self::Now, since: Self::Now) -> Duration;
+    /// Get the elapsed time as `Duration` starting from `since` to `now`
+    /// This is the specialised case for handling the `StartingPoint` in case its type is different
+    /// than the `Now` type.
     fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration;
 
+    /// Convert the specified `Duration` to `i64`
     fn as_i64(&self, duration: Duration) -> i64;
+    /// Convert the specified `Duration` to `Timestamp`
     fn to_timestamp(&self, duration: Duration) -> Timestamp;
 }
 
@@ -104,7 +114,8 @@ impl Timestamp {
         Self(ts as i64)
     }
 
-    //#[cfg(not(feature = "std"))]
+    /// Get UNIX timestamp from the specified `TimeSupplier`
+    #[cfg(not(feature = "std"))]
     pub fn now_nostd<T>(time_supplier: &T) -> Self
     where
         T: TimeSupplier,

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -24,29 +24,33 @@ use instant::SystemTime;
 #[cfg(target_arch = "wasm32")]
 const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 
-//#[cfg(not(feature = "std"))]
-use chrono;
-
 /// Helper trait for acquiring time in `no_std` environments.
 pub trait TimeSupplier {
     type Now;
+    type StartingPoint;
 
     fn now(&self) -> Self::Now;
-    fn starting_point() -> Self::Now;
+    fn starting_point(&self) -> Self::StartingPoint;
     fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration;
+    fn elapsed_duration(now: Self::Now, since: Self::StartingPoint) -> Duration;
 
     fn as_i64(duration: Duration) -> i64;
     fn to_timestamp(duration: Duration) -> Timestamp;
 }
 
-//#[cfg(target_arch = "wasm32")]
+#[cfg(target_arch = "wasm32")]
 use instant::Instant as InstantWasm32;
-//#[cfg(target_arch = "wasm32")]
+#[cfg(target_arch = "wasm32")]
 impl TimeSupplier for InstantWasm32 {
     type Now = InstantWasm32;
+    type StartingPoint = std::time::SystemTime;
 
     fn now(&self) -> Self::Now {
         InstantWasm32::now()
+    }
+
+    fn starting_point(&self) -> Self::Now {
+        std::time::UNIX_EPOCH
     }
 
     fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration {
@@ -101,9 +105,15 @@ impl Timestamp {
     }
 
     //#[cfg(not(feature = "std"))]
-    pub fn now_nostd() -> Self {
-        let now = chrono::Local::now().timestamp;
-        Self(now)
+    pub fn now_nostd<T>(time_supplier: &T) -> Self
+    where
+        T: TimeSupplier,
+    {
+        let now = time_supplier.now();
+        let starting_point = time_supplier.starting_point();
+        let duration = <T as TimeSupplier>::elapsed_duration(now, starting_point);
+
+        <T as TimeSupplier>::to_timestamp(duration)
     }
 
     /// Get timestamp as [`u64`]

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -3,12 +3,15 @@
 
 //! Time
 
-use core::time::Duration;
 use core::ops::{Add, Sub};
 use core::str::FromStr;
+use core::time::Duration;
 
 #[cfg(feature = "std")]
-use std::{fmt, num, time::{SystemTime, UNIX_EPOCH}};
+use std::{
+    fmt, num,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 #[cfg(feature = "alloc")]
 use alloc::fmt;
@@ -21,16 +24,65 @@ use instant::SystemTime;
 #[cfg(target_arch = "wasm32")]
 const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 
+//#[cfg(not(feature = "std"))]
+use chrono;
 
 /// Helper trait for acquiring time in `no_std` environments.
-#[cfg(not(feature = "std"))]
 pub trait TimeSupplier {
     type Now;
 
     fn now(&self) -> Self::Now;
-    fn elapsed_since(&self, since: Self::Now) -> Duration;
+    fn starting_point() -> Self::Now;
+    fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration;
 
-    fn as_i64(&self) -> i64;
+    fn as_i64(duration: Duration) -> i64;
+    fn to_timestamp(duration: Duration) -> Timestamp;
+}
+
+//#[cfg(target_arch = "wasm32")]
+use instant::Instant as InstantWasm32;
+//#[cfg(target_arch = "wasm32")]
+impl TimeSupplier for InstantWasm32 {
+    type Now = InstantWasm32;
+
+    fn now(&self) -> Self::Now {
+        InstantWasm32::now()
+    }
+
+    fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration {
+        now - since
+    }
+
+    fn as_i64(duration: Duration) -> i64 {
+        duration.as_millis() as i64
+    }
+
+    fn to_timestamp(duration: Duration) -> Timestamp {
+        Timestamp(duration.as_millis() as i64)
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+use std::time::Instant;
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+impl TimeSupplier for Instant {
+    type Now = Instant;
+
+    fn now(&self) -> Self::Now {
+        Instant::now()
+    }
+
+    fn elapsed_since(now: Self::Now, since: Self::Now) -> Duration {
+        now - since
+    }
+
+    fn as_i64(duration: Duration) -> i64 {
+        duration.as_millis() as i64
+    }
+
+    fn to_timestamp(duration: Duration) -> Timestamp {
+        Timestamp(duration.as_i64())
+    }
 }
 
 /// Unix timestamp in seconds
@@ -48,9 +100,10 @@ impl Timestamp {
         Self(ts as i64)
     }
 
-    #[cfg(not(feature = "std"))]
-    pub fn now_no_std(time_supplier: &impl TimeSupplier) -> Self {
-        Self(time_supplier.as_i64())
+    //#[cfg(not(feature = "std"))]
+    pub fn now_nostd() -> Self {
+        let now = chrono::Local::now().timestamp;
+        Self(now)
     }
 
     /// Get timestamp as [`u64`]

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -8,10 +8,12 @@ use core::ops::{Add, Sub};
 use core::str::FromStr;
 
 #[cfg(feature = "std")]
-use std::{fmt, time::{SystemTime, UNIX_EPOCH}};
+use std::{fmt, num, time::{SystemTime, UNIX_EPOCH}};
 
 #[cfg(feature = "alloc")]
 use alloc::{fmt, vec::Vec, string::String};
+#[cfg(feature = "alloc")]
+use core::num;
 
 #[cfg(target_arch = "wasm32")]
 use instant::SystemTime;
@@ -60,7 +62,7 @@ impl From<u64> for Timestamp {
 }
 
 impl FromStr for Timestamp {
-    type Err = std::num::ParseIntError;
+    type Err = num::ParseIntError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(s.parse::<i64>()?))
     }

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -3,15 +3,15 @@
 
 //! Time
 
-use std::fmt;
+use core::time::Duration;
+use core::ops::{Add, Sub};
+use core::str::FromStr;
 
-use std::time::Duration;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::{
-    ops::{Add, Sub},
-    str::FromStr,
-};
+#[cfg(feature = "std")]
+use std::{fmt, time::{SystemTime, UNIX_EPOCH}};
+
+#[cfg(feature = "alloc")]
+use alloc::{fmt, vec::Vec, string::String};
 
 #[cfg(target_arch = "wasm32")]
 use instant::SystemTime;
@@ -24,6 +24,7 @@ const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 pub struct Timestamp(i64);
 
 impl Timestamp {
+    #[cfg(not(feature = "alloc"))]
     /// Get UNIX timestamp
     pub fn now() -> Self {
         let ts: u64 = SystemTime::now()
@@ -31,6 +32,10 @@ impl Timestamp {
             .unwrap_or_default()
             .as_secs();
         Self(ts as i64)
+    }
+    #[cfg(feature = "alloc")]
+    pub fn from_secs(external_time_stamp: u64) -> Self {
+        Self(external_time_stamp)
     }
 
     /// Get timestamp as [`u64`]

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -21,13 +21,25 @@ use instant::SystemTime;
 #[cfg(target_arch = "wasm32")]
 const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 
+
+/// Helper trait for acquiring time in `no_std` environments.
+#[cfg(not(feature = "std"))]
+pub trait TimeSupplier {
+    type Now;
+
+    fn now(&self) -> Self::Now;
+    fn elapsed_since(&self, since: Self::Now) -> Duration;
+
+    fn as_i64(&self) -> i64;
+}
+
 /// Unix timestamp in seconds
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Timestamp(i64);
 
 impl Timestamp {
-    #[cfg(not(feature = "alloc"))]
     /// Get UNIX timestamp
+    #[cfg(feature = "std")]
     pub fn now() -> Self {
         let ts: u64 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -35,9 +47,10 @@ impl Timestamp {
             .as_secs();
         Self(ts as i64)
     }
-    #[cfg(feature = "alloc")]
-    pub fn from_secs(external_time_stamp: u64) -> Self {
-        Self(external_time_stamp)
+
+    #[cfg(not(feature = "std"))]
+    pub fn now_no_std(time_supplier: &impl TimeSupplier) -> Self {
+        Self(time_supplier.as_i64())
     }
 
     /// Get timestamp as [`u64`]

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -29,18 +29,25 @@ pub trait TimeSupplier {
     /// The current time from the specified `TimeSupplier`
     type Now: Clone;
     /// The starting point for the specified `TimeSupplier`
-    type StartingPoint;
+    type StartingPoint: Clone;
 
     /// Get the current time as the associated `Now` type
-    fn now(&self) -> Self::Now;
+    fn instant_now(&self) -> Self::Now;
+    /// Get the current time as the associated `StartingPoint` type
+    fn now(&self) -> Self::StartingPoint;
+    /// Get a duration since the StartingPoint.
+    fn duration_since_starting_point(&self, now: Self::StartingPoint) -> Duration;
     /// Get the starting point from the specified `TimeSupplier`
     fn starting_point(&self) -> Self::StartingPoint;
     /// Get the elapsed time as `Duration` starting from `since` to `now`
-    fn elapsed_since(&self, now: Self::Now, since: Self::Now) -> Duration;
+    fn elapsed_instant_since(&self, now: Self::Now, since: Self::Now) -> Duration;
     /// Get the elapsed time as `Duration` starting from `since` to `now`
-    /// This is the specialised case for handling the `StartingPoint` in case its type is different
-    /// than the `Now` type.
-    fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration;
+    fn elapsed_since(&self, now: Self::StartingPoint, since: Self::StartingPoint) -> Duration;
+
+    //  /// Get the elapsed time as `Duration` starting from `since` to `now`
+    //  /// This is the specialised case for handling the `StartingPoint` in case its type is different
+    //  /// than the `Now` type.
+    //  fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration;
 
     /// Convert the specified `Duration` to `i64`
     fn as_i64(&self, duration: Duration) -> i64;
@@ -55,7 +62,7 @@ impl TimeSupplier for InstantWasm32 {
     type Now = InstantWasm32;
     type StartingPoint = std::time::SystemTime;
 
-    fn now(&self) -> Self::Now {
+    fn instant_now(&self) -> Self::Now {
         InstantWasm32::now()
     }
 
@@ -83,27 +90,41 @@ impl TimeSupplier for Instant {
     type Now = Instant;
     type StartingPoint = std::time::SystemTime;
 
-    fn now(&self) -> Self::Now {
+    fn now(&self) -> Self::StartingPoint {
+        SystemTime::now()
+    }
+
+    fn instant_now(&self) -> Self::Now {
         Instant::now()
+    }
+
+    fn duration_since_starting_point(&self, now: Self::StartingPoint) -> Duration {
+        now.duration_since(self.starting_point()).expect("duration_since panicked")
     }
 
     fn starting_point(&self) -> Self::StartingPoint {
         std::time::UNIX_EPOCH
     }
 
-    fn elapsed_since(&self, now: Self::Now, since: Self::Now) -> Duration {
-        now - since
-    }
-    fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration {
+    fn elapsed_instant_since(&self, now: Self::Now, since: Self::Now) -> Duration {
         now - since
     }
 
+    fn elapsed_since(&self, now: Self::StartingPoint, since: Self::StartingPoint) -> Duration {
+        now.duration_since(since).expect("duration_since panicked")
+    }
+
+//     fn elapsed_duration(&self, now: Self::Now, since: Self::StartingPoint) -> Duration {
+//         let dur = since.duration_since(self.starting_point).expect("Clock may have gone backwards");
+//         now - since
+//     }
+// 
     fn as_i64(&self, duration: Duration) -> i64 {
         duration.as_millis() as i64
     }
 
     fn to_timestamp(&self, duration: Duration) -> Timestamp {
-        Timestamp(duration.as_i64())
+        Timestamp(self.as_i64(duration))
     }
 }
 

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -3,15 +3,15 @@
 
 //! Time
 
-use core::time::Duration;
-use core::ops::{Add, Sub};
-use core::str::FromStr;
+use std::fmt;
 
-#[cfg(feature = "std")]
-use std::{fmt, time::{SystemTime, UNIX_EPOCH}};
-
-#[cfg(feature = "alloc")]
-use alloc::{fmt, vec::Vec, string::String};
+use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    ops::{Add, Sub},
+    str::FromStr,
+};
 
 #[cfg(target_arch = "wasm32")]
 use instant::SystemTime;
@@ -24,7 +24,6 @@ const UNIX_EPOCH: SystemTime = SystemTime::UNIX_EPOCH;
 pub struct Timestamp(i64);
 
 impl Timestamp {
-    #[cfg(not(feature = "alloc"))]
     /// Get UNIX timestamp
     pub fn now() -> Self {
         let ts: u64 = SystemTime::now()
@@ -32,10 +31,6 @@ impl Timestamp {
             .unwrap_or_default()
             .as_secs();
         Self(ts as i64)
-    }
-    #[cfg(feature = "alloc")]
-    pub fn from_secs(external_time_stamp: u64) -> Self {
-        Self(external_time_stamp)
     }
 
     /// Get timestamp as [`u64`]


### PR DESCRIPTION
This PR adds `no_std` compatibility to the `nostr` crate only, other crates were not modified.

The PR also contains a dummy `no_std` binary crate which served as test crate for making sure the port was indeed `no_std` compatible.